### PR TITLE
Fix invalid element type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `LoginOptions` throwing error on invalid element type
 
 ## [1.1.0] - 2018-08-02
 ### Added

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -65,12 +65,15 @@ class LoginOptions extends Component {
             </li>
           }
           {options.providers && options.providers.map(({ providerName }, index) => {
+            const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
+
             return (
-              <li className={`vtex-login-options__list-item vtex-login-options__list-item--${providerName} mb3`}
+              <li
+                className={`vtex-login-options__list-item vtex-login-options__list-item--${providerName} mb3`}
                 key={`${providerName}-${index}`}
               >
                 <OAuth provider={providerName}>
-                  {React.createElement(PROVIDERS_ICONS[providerName])}
+                  {hasIcon ? React.createElement(PROVIDERS_ICONS[providerName], null) : null}
                 </OAuth>
               </li>
             )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add precheck for existing `PROVIDER_ICON` before rendering.

#### What problem is this solving?
When the API returned a provider other than Facebook or Google, the component would crash.

#### How should this be manually tested?
[Workspace](https://login--storecomponents.myvtex.com/).

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)