### PR TITLE
Fix Login page options when displaying the login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Login page options when displaying login form.
 
 ## [1.1.2] - 2018-08-07
 ### Changed

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -46,7 +46,7 @@ class LoginOptions extends Component {
       <div className={classes}>
         <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
         <ul className="vtex-login-options__list list pa0">
-          {this.showOption('classicAuthentication', 'loginOptions.emailVerification') &&
+          {this.showOption('accessKeyAuthentication', 'loginOptions.emailVerification') &&
             <li className="vtex-login-options__list-item mb3">
               <div className="vtex-login__button">
                 <Button
@@ -58,7 +58,7 @@ class LoginOptions extends Component {
               </div>
             </li>
           }
-          {this.showOption('accessKeyAuthentication', 'loginOptions.emailAndPassword') &&
+          {this.showOption('classicAuthentication', 'loginOptions.emailAndPassword') &&
             <li className="vtex-login-options__list-item mb3">
               <div className="vtex-login__button">
                 <Button

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -23,6 +23,11 @@ class LoginOptions extends Component {
     this.props.onOptionsClick(el)
   }
 
+  showOption = (option, optionName) => {
+    const { isAlwaysShown, currentStep, options } = this.props
+    return options[option] && !isAlwaysShown ? true : currentStep !== optionName
+  }
+
   render() {
     const {
       className,
@@ -41,7 +46,7 @@ class LoginOptions extends Component {
       <div className={classes}>
         <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
         <ul className="vtex-login-options__list list pa0">
-          {options.classicAuthentication &&
+          {this.showOption('classicAuthentication', 'loginOptions.emailVerification') &&
             <li className="vtex-login-options__list-item mb3">
               <div className="vtex-login__button">
                 <Button
@@ -53,7 +58,7 @@ class LoginOptions extends Component {
               </div>
             </li>
           }
-          {options.accessKeyAuthentication &&
+          {this.showOption('accessKeyAuthentication', 'loginOptions.emailAndPassword') &&
             <li className="vtex-login-options__list-item mb3">
               <div className="vtex-login__button">
                 <Button


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix Login page options when displaying the login form

#### What problem is this solving?
The button corresponding to the form displayed should be hidden.

#### How should this be manually tested?
https://andre--storecomponents.myvtex.com/login

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)