### PR TITLE
Update the Login to receive class-names for the Icon and Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.1] - 2018-09-05
 ### Changed
 - Update the `Login` to receive classnames for the label and icon.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update the `Login` to receive classnames for the label and icon.
 
 ## [1.4.0] - 2018-08-31
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/Login.js
+++ b/react/Login.js
@@ -16,9 +16,16 @@ import { LoginPropTypes } from './propTypes'
 
 import './global.css'
 
+const DEFAULT_CLASSES = 'white'
+
 /** Canonical login that calls a mutation to retrieve the authentication token */
 class Login extends Component {
   static propTypes = LoginPropTypes
+
+  static defaultProps = {
+    labelClasses: DEFAULT_CLASSES,
+    iconClasses: DEFAULT_CLASSES,
+  }
 
   state = {
     isBoxOpen: false,
@@ -87,16 +94,16 @@ class Login extends Component {
     const { iconSize, iconLabel, labelClasses, iconClasses, intl } = this.props
     const iconContent = (
       <Fragment>
-        <div className={`${iconClasses || 'white'}`}>
+        <div className={`${iconClasses}`}>
           <ProfileIcon size={iconSize} fillColor="currentColor" />
         </div>
         {profile ? (
-          <span className={`vtex-login__profile order-1 f6 pl4 ${labelClasses || 'white'}`}>
+          <span className={`vtex-login__profile order-1 f6 pl4 ${labelClasses}`}>
             {translate('login.hello', intl)}{' '}
             {truncateString(profile.firstName) || truncateString(profile.email)}
           </span>
         ) : (
-          iconLabel && <span className={`vtex-login__label f6 pl4 ${labelClasses || 'white'}`}>{iconLabel}</span>
+          iconLabel && <span className={`vtex-login__label f6 pl4 ${labelClasses}`}>{iconLabel}</span>
         )}
       </Fragment>
     )

--- a/react/Login.js
+++ b/react/Login.js
@@ -84,17 +84,19 @@ class Login extends Component {
 
   renderIcon() {
     const { renderIconAsLink, profile } = this.state
-    const { iconSize, iconLabel, iconColor, intl } = this.props
+    const { iconSize, iconLabel, labelClasses, iconClasses, intl } = this.props
     const iconContent = (
       <Fragment>
-        <ProfileIcon size={iconSize} fillColor={iconColor} />
+        <div className={`${iconClasses || 'white'}`}>
+          <ProfileIcon size={iconSize} fillColor="currentColor" />
+        </div>
         {profile ? (
-          <span className="vtex-login__profile order-1 white f6 pl4">
+          <span className={`vtex-login__profile order-1 f6 pl4 ${labelClasses || 'white'}`}>
             {translate('login.hello', intl)}{' '}
             {truncateString(profile.firstName) || truncateString(profile.email)}
           </span>
         ) : (
-          iconLabel && <span className="vtex-login__label white f6 pl4">{iconLabel}</span>
+          iconLabel && <span className={`vtex-login__label f6 pl4 ${labelClasses || 'white'}`}>{iconLabel}</span>
         )}
       </Fragment>
     )
@@ -126,7 +128,7 @@ class Login extends Component {
   }
 
   render() {
-    const { intl, ...others } = this.props
+    const { ...others } = this.props
     const { isBoxOpen, profile } = this.state
 
     const boxPositionStyle = {

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -25,8 +25,10 @@ export const LoginPropTypes = {
   showPasswordVerificationIntoTooltip: PropTypes.bool,
   /** Icon's size */
   iconSize: PropTypes.number,
-  /** Icon's color */
-  iconColor: PropTypes.string,
+  /** Icon's classnames */
+  iconClasses: PropTypes.string,
   /** Icon's label */
   iconLabel: PropTypes.string,
+  /** Label's classnames */
+  labelClasses: PropTypes.string,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the Login to receive class-names for the Icon and Label.

#### What problem is this solving?
The Login was receiving an hexadecimal color to set the icon and label color.

#### How should this be manually tested?
[Click here to access the workspace.](https://waza2--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
