### PR TITLE
Add withSession to the LoginContent component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add HOC `withSession` to the `LoginContent` component.
 
 ## [1.5.0] - 2018-09-06
 ### Added

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { graphql } from 'react-apollo'
 import { injectIntl } from 'react-intl'
+import { Transition } from 'react-spring'
+import { withSession } from 'render'
 
 import LoginOptions from './components/LoginOptions'
 import EmailVerification from './components/EmailVerification'
@@ -17,7 +19,6 @@ import LoginOptionsQuery from './queries/loginOptions.gql'
 import { LoginSchema } from './schema'
 import { LoginPropTypes } from './propTypes'
 
-import { Transition } from 'react-spring'
 
 import './global.css'
 
@@ -317,5 +318,5 @@ LoginWithIntl.schema = {
   },
 }
 
-export default graphql(LoginOptionsQuery)(LoginWithIntl)
+export default withSession()(graphql(LoginOptionsQuery)(LoginWithIntl))
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `withSession` HOC to the `LoginContent` component

#### What problem is this solving?
The session wasn´t being initialized when only the LoginContent was used.

#### How should this be manually tested?
[workspace](https://felipe--storecomponents.myvtex.com/lg/s?map=ft)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
