### PR TITLE
Login does not break when there are no options. Now it allows the use…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.5.5] - 2018-09-26
 ### Fixed
 - Login does not break when there are no options. Now it allows the user to refetch it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Login does not break when there are no options. Now it allows the user to refetch it.
 
 ## [1.5.4] - 2018-09-24
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/Login.js
+++ b/react/Login.js
@@ -90,9 +90,9 @@ const options = {
   options: () => ({ ssr: false }),
 }
 
-const LoginWithSession = withSession(
-  { loading: () => <div></div> }
-)(compose(
+const LoginWithSession = withSession({
+  loading: () => <div></div>
+})(compose(
   injectIntl,
   graphql(GET_USER_PROFILE, options),
 )(LoginComponent))

--- a/react/Login.js
+++ b/react/Login.js
@@ -90,7 +90,9 @@ const options = {
   options: () => ({ ssr: false }),
 }
 
-const LoginWithSession = withSession()(compose(
+const LoginWithSession = withSession(
+  { loading: () => <div></div> }
+)(compose(
   injectIntl,
   graphql(GET_USER_PROFILE, options),
 )(LoginComponent))

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -216,6 +216,9 @@ class LoginContent extends Component {
     const { data : query } = this.props
     if (!query.loading && !query.loginOptions) {
       return query.refetch()
+    } 
+    if (query.loginOptions) {
+      return Promise.resolve()
     }
   }
 

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -214,7 +214,7 @@ class LoginContent extends Component {
 
   refetchOptions = () => {
     const { data : query } = this.props
-    if (true && !query.loading /* && !query.loadingOptions */) {
+    if (!query.loading && !query.loginOptions) {
       return query.refetch()
     }
   }

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -212,6 +212,13 @@ class LoginContent extends Component {
     })
   }
 
+  refetchOptions = () => {
+    const { data : query } = this.props
+    if (true && !query.loading /* && !query.loadingOptions */) {
+      return query.refetch()
+    }
+  }
+
   renderChildren = style => {
     const {
       profile,
@@ -239,6 +246,7 @@ class LoginContent extends Component {
           currentStep={step === 0 ? 'loginOptions.emailVerification' : 'loginOptions.emailAndPassword'}
           isAlwaysShown={!isInitialScreenOptionOnly}
           onOptionsClick={this.handleOptionsClick}
+          refetchOptions={this.refetchOptions}
         />
       </div>
     )

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -19,13 +19,25 @@ const PROVIDERS_ICONS = {
 
 /** LoginOptions tab component. Displays a list of login options */
 class LoginOptions extends Component {
+  state = {
+    loadingOptions: false
+  }
+
+  handleRefetchOptions = () => {
+    if (!this.state.loadingOptions) {
+      this.setState({ loadingOptions: true })
+      this.props.refetchOptions()
+        .then(() => this.setState({ loadingOptions: false }))
+    }
+  }
+
   handleOptionClick = el => () => {
     this.props.onOptionsClick(el)
   }
 
   showOption = (option, optionName) => {
     const { isAlwaysShown, currentStep, options } = this.props
-    return options[option] && !isAlwaysShown ? true : currentStep !== optionName
+    return options && (options[option] && !isAlwaysShown ? true : currentStep !== optionName)
   }
 
   render() {
@@ -37,6 +49,8 @@ class LoginOptions extends Component {
       intl,
       isAlwaysShown,
     } = this.props
+
+    const { loadingOptions } = this.state
 
     const classes = classNames('vtex-login-options', className, {
       'vtex-login-options--sticky': isAlwaysShown,
@@ -70,7 +84,7 @@ class LoginOptions extends Component {
               </div>
             </li>
           }
-          {options.providers && options.providers.map(({ providerName }, index) => {
+          {options && options.providers && options.providers.map(({ providerName }, index) => {
             const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
 
             return (
@@ -84,6 +98,21 @@ class LoginOptions extends Component {
               </li>
             )
           })}
+          {!options && (
+            <li className="vtex-login-options__list-item mb3">
+              <div className="vtex-login__button vtex-login__button--danger">
+                <Button
+                  type="danger"
+                  variation="secondary"
+                  isLoading={loadingOptions}
+                  onClick={this.handleRefetchOptions}
+                >
+                  <div className={`${loadingOptions ? 'dn' : 'db'} f6`}>{translate('loginOptions.error.title', intl)}</div>
+                  <span className="f7 pt1">{translate('loginOptions.error.subhead', intl)}</span>
+                </Button>
+              </div>
+            </li>
+          )}
           <li className="vtex-login-options__list-item vtex-login-options__list-item--container mb3">
             <ExtensionContainer id="container" />
           </li>
@@ -98,6 +127,8 @@ LoginOptions.propTypes = {
   intl: intlShape,
   /** Function to change de active tab */
   onOptionsClick: PropTypes.func.isRequired,
+  /** Function to refetch login options */
+  refetchOptions: PropTypes.func.isRequired,
   /** Title that will be shown on top */
   title: PropTypes.string.isRequired,
   /** Fallback title that will be shown if there's no title */

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -37,7 +37,7 @@ class LoginOptions extends Component {
 
   showOption = (option, optionName) => {
     const { isAlwaysShown, currentStep, options } = this.props
-    return options && (options[option] && !isAlwaysShown ? true : currentStep !== optionName)
+    return options && ((options[option] && !isAlwaysShown) || currentStep !== optionName)
   }
 
   render() {

--- a/react/global.css
+++ b/react/global.css
@@ -152,3 +152,12 @@
   border-style: solid;
   border-color: #3b3b3b transparent transparent transparent;
 }
+
+.vtex-login__button--danger > .vtex-button {
+  background-color: #ffe6e6;
+  color: #FF4C4C;
+}
+
+.vtex-login__button--danger > .vtex-button .vtex__icon-spinner{
+  color: #FF4C4C;
+}

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -4,7 +4,7 @@
     "loginOptions.emailAndPassword": "Sign in with email and password",
     "loginOptions.oAuth": "Sign in with",
     "loginOptions.error.title": "Something bad happened...",
-    "loginOptions.error.subhead": "Try again.",
+    "loginOptions.error.subhead": "Click to try again.",
     "login.goBack": "Go back",
     "login.send": "Send",
     "login.create": "Create",

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -3,6 +3,8 @@
     "loginOptions.emailVerification": "Receive access code by email",
     "loginOptions.emailAndPassword": "Sign in with email and password",
     "loginOptions.oAuth": "Sign in with",
+    "loginOptions.error.title": "Something bad happened...",
+    "loginOptions.error.subhead": "Try again.",
     "login.goBack": "Go back",
     "login.send": "Send",
     "login.create": "Create",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -3,6 +3,8 @@
     "loginOptions.emailVerification": "Recibir código de acceso por correo electrónico",
     "loginOptions.emailAndPassword": "Entrar con correo electrónico y contraseña",
     "loginOptions.oAuth": "Entrar con",
+    "loginOptions.error.title": "Algo incorrecto sucedió...",
+    "loginOptions.error.subhead": "Intentar nuevamente.",
     "login.goBack": "Volver",
     "login.send": "Enviar",
     "login.create": "Crear",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -4,7 +4,7 @@
     "loginOptions.emailAndPassword": "Entrar con correo electrónico y contraseña",
     "loginOptions.oAuth": "Entrar con",
     "loginOptions.error.title": "Algo incorrecto sucedió...",
-    "loginOptions.error.subhead": "Intentar nuevamente.",
+    "loginOptions.error.subhead": "Haga clic to intentar nuevamente.",
     "login.goBack": "Volver",
     "login.send": "Enviar",
     "login.create": "Crear",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -3,6 +3,8 @@
     "loginOptions.emailVerification": "Receber código de acesso por e-mail",
     "loginOptions.emailAndPassword": "Entrar com e-mail e senha",
     "loginOptions.oAuth": "Entrar com",
+    "loginOptions.error.title": "Algo errado aconteceu...",
+    "loginOptions.error.subhead": "Tentar novamente.",
     "login.goBack": "Voltar",
     "login.send": "Enviar",
     "login.create": "Criar",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -4,7 +4,7 @@
     "loginOptions.emailAndPassword": "Entrar com e-mail e senha",
     "loginOptions.oAuth": "Entrar com",
     "loginOptions.error.title": "Algo errado aconteceu...",
-    "loginOptions.error.subhead": "Tentar novamente.",
+    "loginOptions.error.subhead": "Clique para tentar novamente.",
     "login.goBack": "Voltar",
     "login.send": "Enviar",
     "login.create": "Criar",


### PR DESCRIPTION
…r to refetch it.

#### What is the purpose of this pull request?

Login does not break when there are no options. Now it allows the user to refetch it.

#### What problem is this solving?

1. Login was breaking when there was no options object;
2. When loading session, login was a spinner, but it was supposed to show nothing.

#### Screenshots or example usage

[Workspace](https://estacio--storecomponents.myvtex.com)

![refetching options](https://user-images.githubusercontent.com/15948386/46038508-a26c9600-c0e1-11e8-9e00-fcb6be90e022.gif)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
