### PR TITLE
Await to logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Await before logout to avoid reloading before logging out
 
 ## [1.6.0] - 2018-10-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.1] - 2018-10-02
 ### Fixed
 - Await before logout to avoid reloading before logging out
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -17,8 +17,8 @@ class AccountOptions extends Component {
     logout: PropTypes.func,
   }
 
-  handleLogoutClick = () => {
-    this.props.logout()
+  handleLogoutClick = async () => {
+    await this.props.logout()
     location.assign('/') // Needed to refetch all the data from GraphQL.
   }
 

--- a/react/mutations/accessKeySignIn.gql
+++ b/react/mutations/accessKeySignIn.gql
@@ -1,4 +1,3 @@
-mutation accessKeySignIn($email: String!, $code: String!) 
-  @context(scope: "private") {
+mutation accessKeySignIn($email: String!, $code: String!)  {
   accessKeySignIn(email: $email, code: $code) 
 }

--- a/react/mutations/classicSignIn.gql
+++ b/react/mutations/classicSignIn.gql
@@ -1,4 +1,3 @@
-mutation classicSignIn($email: String!, $password: String!) 
-  @context(scope: "private") {
+mutation classicSignIn($email: String!, $password: String!) {
   classicSignIn(email: $email, password: $password) 
 }

--- a/react/mutations/logout.gql
+++ b/react/mutations/logout.gql
@@ -1,3 +1,3 @@
-mutation logout @context(scope: "private") {
+mutation logout {
   logout
 }

--- a/react/mutations/recoveryPassword.gql
+++ b/react/mutations/recoveryPassword.gql
@@ -1,4 +1,3 @@
-mutation recoveryPassword($email: String!, $newPassword: String!, $code: String!) 
-  @context(scope: "private") {
+mutation recoveryPassword($email: String!, $newPassword: String!, $code: String!) {
   recoveryPassword(email: $email, newPassword: $newPassword, code: $code) 
 }

--- a/react/mutations/sendEmailVerification.gql
+++ b/react/mutations/sendEmailVerification.gql
@@ -1,4 +1,3 @@
-mutation sendEmailVerification($email: String!) 
-  @context(scope: "private") {
+mutation sendEmailVerification($email: String!) {
   sendEmailVerification(email: $email)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Login was not working 100% because, sometimes, the reload started before the `logout` query had removed the `VtexIdClientAuthCookie`. Awaiting before reloading fix the problem

Also, this pr removes the legacy `@context(scope: private)` hints to avoid confusions

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
