### PR TITLE
Fix warning message on function child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.2] - 2018-10-09
 ### Fixed
 - Warning message on loading element being a function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Warning message on loading element being a function.
 
 ## [1.6.1] - 2018-10-02
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/Login.js
+++ b/react/Login.js
@@ -92,7 +92,7 @@ const options = {
 }
 
 const LoginWithSession = withSession({
-  loading: () => <div></div>
+  loading: <div />,
 })(compose(
   injectIntl,
   graphql(Queries.session, options),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change loading of the `withSession` hoc to be a react element, instead of a function.

#### What problem is this solving?
React was warning on the console because functions are not valid as a child.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
