### PR TITLE
Use filled icons from IconPack instead local icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.2] - 2018-11-23
 ### Changed
 - Use icons from the dreamstore icon pack.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use icons from the dreamstore icon pack.
 
-
 ## [2.0.1] - 2018-11-09
 ### Fixed
 - Fix redirect behavior, now this function is called only when `/login` is in path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use icons from the dreamstore icon pack.
+
 
 ## [2.0.1] - 2018-11-09
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.styleguide": "6.x",
+    "vtex.styleguide": "7.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-session": "0.x",
     "vtex.store": "1.x"

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
     "vtex.styleguide": "7.x",
     "vtex.store-graphql": "2.x",
     "vtex.store-session": "0.x",
-    "vtex.store": "1.x"
+    "vtex.store": "1.x",
+    "vtex.use-svg": "0.x"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -33,7 +33,6 @@ export default class LoginComponent extends Component {
       data,
     } = this.props
 
-    console.log(iconSize)
     const profile = getProfile(data)
 
     const iconContent = (

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -33,6 +33,7 @@ export default class LoginComponent extends Component {
       data,
     } = this.props
 
+    console.log(iconSize)
     const profile = getProfile(data)
 
     const iconContent = (
@@ -46,8 +47,8 @@ export default class LoginComponent extends Component {
             {profile.firstName || truncateString(profile.email)}
           </span>
         ) : (
-          iconLabel && <span className={`vtex-login__label f6 pl4 ${labelClasses} dn-m db-l`}>{iconLabel}</span>
-        )}
+            iconLabel && <span className={`vtex-login__label f6 pl4 ${labelClasses} dn-m db-l`}>{iconLabel}</span>
+          )}
       </Fragment>
     )
 
@@ -93,7 +94,7 @@ export default class LoginComponent extends Component {
             <div
               className={`vtex-login__box absolute z-max ${
                 isBoxOpen ? 'flex' : 'dn'
-              }`}
+                }`}
               style={boxPositionStyle}
             >
               <div className="vtex-login__arrow-up absolute top-0 right-0 shadow-3 bg-base" />

--- a/react/images/EyeSightDisable.js
+++ b/react/images/EyeSightDisable.js
@@ -1,24 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Icon from 'vtex.use-svg/Icon'
 
 /**
  * Eyesight disabled icon component in svg
  */
-const EyeSightDisable = ({ size, fillColor }) => {
+const EyeSightDisable = ({ size, fillColor, viewBox }) => {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-    >
-      <use
-        fill={fillColor}
-        href="#eyesight-disable"
-        xlinkHref="#eyesight-disable"
-      />
-    </svg>
+    <Icon
+      id="eyesight-disable"
+      size={size}
+      viewBox={viewBox}
+      color={fillColor}
+    />
   )
 }
 
@@ -27,11 +21,14 @@ EyeSightDisable.propTypes = {
   size: PropTypes.number,
   /* Fill color for the icon */
   fillColor: PropTypes.string,
+  /* Icon viewBox */
+  viewBox: PropTypes.string
 }
 
 EyeSightDisable.defaultProps = {
   size: 14,
   fillColor: '#444444',
+  viewBox: '0 0 16 16'
 }
 
 export default EyeSightDisable

--- a/react/images/EyeSightEnable.js
+++ b/react/images/EyeSightEnable.js
@@ -1,24 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Icon from 'vtex.use-svg/Icon'
 
 /**
  * Eyesight enabled icon component in svg
  */
-const EyeSightEnable = ({ size, fillColor }) => {
+const EyeSightEnable = ({ size, fillColor, viewBox }) => {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-    >
-      <use
-        fill={fillColor}
-        href="#eyesight-enable"
-        xlinkHref="#eyesight-enable"
-      />
-    </svg>
+    <Icon
+      id="eyesight-enable"
+      size={size}
+      viewBox={viewBox}
+      color={fillColor}
+    />
   )
 }
 
@@ -27,11 +21,14 @@ EyeSightEnable.propTypes = {
   size: PropTypes.number,
   /* Fill color for the icon */
   fillColor: PropTypes.string,
+  /* Icon viewBox */
+  viewBox: PropTypes.string
 }
 
 EyeSightEnable.defaultProps = {
   size: 14,
   fillColor: '#444444',
+  viewBox: '0 0 16 16'
 }
 
 export default EyeSightEnable

--- a/react/images/ProfileIcon.js
+++ b/react/images/ProfileIcon.js
@@ -1,22 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
+import Icon from 'vtex.use-svg/Icon'
 /**
  * Profile icon component in svg
  */
-const ProfileIcon = ({ size, fillColor }) => {
+const ProfileIcon = ({ size, fillColor, viewBox }) => {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-      width={size}
-      height={size}
-      viewBox="0 0 22 22"
-      fill="none"
+    <Icon
+      id="profile"
+      size={size}
+      viewBox={viewBox}
       color={fillColor}
-    >
-      <use href="#profile" xlinkHref="#profile" />
-    </svg>
+    />
   )
 }
 
@@ -25,11 +20,14 @@ ProfileIcon.propTypes = {
   size: PropTypes.number,
   /* Fill color for the icon */
   fillColor: PropTypes.string,
+  /* Icon Viewbox */
+  viewBox: PropTypes.string
 }
 
 ProfileIcon.defaultProps = {
   size: 20,
   fillColor: 'currentColor',
+  viewBox: '0 0 22 22'
 }
 
 export default ProfileIcon

--- a/react/images/ProfileIcon.js
+++ b/react/images/ProfileIcon.js
@@ -11,7 +11,7 @@ const ProfileIcon = ({ size, fillColor }) => {
       xmlnsXlink="http://www.w3.org/1999/xlink"
       width={size}
       height={size}
-      viewBox="0 0 44 44"
+      viewBox="0 0 22 22"
       fill="none"
       color={fillColor}
     >


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
By design requirement it is necessary to use filled icons instead of the outline icons.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Using icons from `vtex.styleguide`.

#### How should this be manually tested?
https://filled--storecomponents.myvtex.com/

#### Screenshots or example usage
![frame_2](https://user-images.githubusercontent.com/17649410/48709058-19ef0b00-ebe3-11e8-8def-ae06d8adcdb2.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
