### PR TITLE
Remove typo in access code placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove typo in access code placeholder.
 
 ## [1.6.8] - 2018-12-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.9] - 2018-12-17
 ### Fixed
 - Remove typo in access code placeholder.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -34,7 +34,7 @@
     "login.password.tooltip.title": "Sua senha precisa ter:",
     "login.email.placeholder": "Ex.: example@mail.com",
     "login.password.placeholder": "Adicione sua senha",
-    "login.accessCode.placeholder": "Adicionse seu código de acesso",
+    "login.accessCode.placeholder": "Adicione seu código de acesso",
     "editor.login.isInitialScreenOptionOnly.title": "Mostrar apenas as opções de login na tela inicial",
     "editor.login.defaultOption.title": "Formulário inicial a ser mostrado",
     "editor.login.defaultOption.token": "Login por código de acesso",


### PR DESCRIPTION

![image 7](https://user-images.githubusercontent.com/8000984/50090232-b27aaa00-01e6-11e9-955e-40bd6938c090.png)

<img width="285" alt="screen shot 2018-12-17 at 10 37 28" src="https://user-images.githubusercontent.com/8000984/50090596-cd99e980-01e7-11e9-8f01-8593a89d1594.png">


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
