### PR TITLE
Improve regex for email validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.6.10] - 2019-02-12
 ### Fixed
 - Improve regex for email validation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Improve regex for email validation.
 
 ## [1.6.9] - 2018-12-17
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/utils/format-check.js
+++ b/react/utils/format-check.js
@@ -4,7 +4,7 @@ export const isValidPassword = password => {
 }
 
 export const isValidEmail = email => {
-  const pattern = new RegExp(/^[+a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i)
+  const pattern = new RegExp(/^(([^<>()\[\]\\.,;:\s@!"]+(\.[^<>()\[\]\\.,;:\s@!"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/)
   return pattern.test(email)
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix bug where email extensions can't have more than four characters

#### What problem is this solving?
Email extensions should be allowed to have more characteres

#### How should this be manually tested?
Open login component and try typing an email, it should accept the same emails as before as well as emails with extensions longer than 4 characteres

#### Screenshots or example usage

#### Types of changes
- [ x ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
