### PR TITLE
fix react-vtexid scope value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `react-vtexid` scope value.
 
 ## [2.7.2] - 2019-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.7.3] - 2019-02-12
 ### Fixed
 - Fix `react-vtexid` scope value.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.2",
+  "version": "2.7.3",
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -305,7 +305,7 @@ class LoginContent extends Component {
     })
 
     return (
-      <AuthState scope="store">
+      <AuthState scope="STORE">
         {() => (
           <div className={className}>
             <Transition


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix `react-vtexid`'s `<AuthState />` usage broken after migration from `2.x` to `4.x`.

#### What problem is this solving?
Fix `<AuthState />` scope value. It expects `ADMIN` or `STORE`. Was receiving `store`.

#### How should this be manually tested?
Link any account with the login component and see if the following error occurs:
![image](https://user-images.githubusercontent.com/8474847/51843561-69943600-22fa-11e9-9889-213c1f86989d.png)

**If it doesn't**, then we're fine =D

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
