### PR TITLE
Fix encoding of returnUrl query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Encoding of `returnUrl` query param.
 
 ## [2.6.0] - 2019-01-28
 

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -140,15 +140,12 @@ class LoginContent extends Component {
     email: '',
     password: '',
     code: '',
-    returnUrl: '/',
+    returnUrl: this.props.query && this.props.query.returnUrl || '/',
   }
 
   componentDidMount() {
     if (location.href.indexOf('accountAuthCookieName') > 0) {
       setCookie(location.href)
-    }
-    if (location.search) {
-      this.setState({ returnUrl: location.search.substring(11) })
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Read the `returnUrl` query param from the props passed from render, instead of manually reading it from `location.search`.

#### What problem is this solving?
The url query param `returnUrl` wasn't being encoded before (which resulted in an error when you refreshed the page), and the login component used the exact same value as in the URL.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/account).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
