### PR TITLE
Fix/return url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.9.1] - 2019-04-30
 ### Changed
 - Fixes user redirection after OAuth login
 - Validates the return URL to prevent [Open Redirect](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixes user redirection after OAuth login
+- Validates the return URL to prevent [Open Redirect](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md)
 
 ## [2.9.0] - 2019-04-24
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -218,7 +218,7 @@ class LoginContent extends Component {
         // components using authentication and relying
         // on the session cookie haven't been updated yet,
         // so the refresh is intentional.
-        location.assign(this.returnUrl)
+        location.assign(`/api/vtexid/pub/authentication/redirect?returnUrl=${encodeURIComponent(this.returnUrl)}`)
       }
     })
   }
@@ -321,7 +321,7 @@ class LoginContent extends Component {
     const formClassName = classNames(styles.contentForm, 'dn ph4 pb6', {
       [`${styles.contentFormVisible} db `]: this.shouldRenderForm,
     })
-
+    
     return (
       <AuthState scope="STORE" returnUrl={this.returnUrl}>
         {() => (

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -323,7 +323,7 @@ class LoginContent extends Component {
     })
 
     return (
-      <AuthState scope="STORE">
+      <AuthState scope="STORE" returnUrl={this.returnUrl}>
         {() => (
           <div className={className}>
             <Transition


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR has two purposes:
1. Fix the user redirection after OAuth login
2. Validate the return URL to prevent [Open Redirect Vulnerability](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md)

#### What problem is this solving?

1. The user wasn't being redirected after logging in with OAuth
2. The user could be redirected to any untrusted domain

#### How should this be manually tested?
Go to [`bezerra`'s workspace on `storecomponents`](https://bezerra--storecomponents.myvtex.com/login?returnUrl=https%3A%2F%2Fbezerra--storecomponents.myvtex.com%2Fdecoration%23) and try to log in. You should be redirected to https://bezerra--storecomponents.myvtex.com/decoration when the login finishes.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
