### PR TITLE
Fix login redirections from any page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.0] - 2019-05-02
 ### Changed
 - Fix redirection after OAuth login.
 - Pass the `returnUrl` query when the user opens login on mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Fixes redirection after OAuth login when the user is in any page.
-- Pass the returnUrl query when open login in mobile version.
+- Fix redirection after OAuth login.
+- Pass the `returnUrl` query when the user opens login on mobile.
 
 ## [2.9.2] - 2019-04-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Fixes redirection after OAuth login when the user is in all the pages
-- Pass the returnUrl query when open login in mobile version
+- Fixes redirection after OAuth login when the user is in any page.
+- Pass the returnUrl query when open login in mobile version.
 
 ## [2.9.2] - 2019-04-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fixes redirection after OAuth login when the user is in all the pages
+- Pass the returnUrl query when open login in mobile version
 
 ## [2.9.2] - 2019-04-30
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -116,6 +116,13 @@ class LoginContent extends Component {
     /** Runtime context. */
     runtime: PropTypes.shape({
       navigate: PropTypes.func,
+      page: PropTypes.string,
+      history: PropTypes.shape({
+        location: PropTypes.shape({
+          pathname: PropTypes.string,
+          search: PropTypes.string,
+        }),
+      }),
     }),
     /* Reused props */
     optionsTitle: LoginPropTypes.optionsTitle,

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { compose, pathOr } from 'ramda'
+import { compose, path } from 'ramda'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { graphql } from 'react-apollo'
@@ -147,7 +147,11 @@ class LoginContent extends Component {
     code: '',
   }
 
-  returnUrl = pathOr('/', ['query', 'returnUrl'], this.props)
+  get returnUrl() {
+    const { runtime: { page, history: { location: { pathname, search } } } } = this.props
+    const currentUrl = page !== 'store.login' ? `${pathname}${search}` : '/'
+    return path(['query', 'returnUrl'], this.props) || currentUrl
+  }
 
   componentDidMount() {
     if (location.href.indexOf('accountAuthCookieName') > 0) {

--- a/react/__mocks__/vtex.render-runtime.js
+++ b/react/__mocks__/vtex.render-runtime.js
@@ -10,5 +10,18 @@ export const Link = ({ page, className, children }) => (
   </a>
 )
 
-export const withRuntimeContext = comp => comp
+// eslint-disable-next-line react/display-name
+export const withRuntimeContext = WrappedComponent => props => {
+  const mockedRuntime = {
+    page: '',
+    history: {
+      location: {
+        pathname: '',
+        search: '',
+      },
+    },
+  }
+  return <WrappedComponent {...props} runtime={mockedRuntime} />
+}
+
 export const withSession = () => comp => comp

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from 'react'
-import { Link } from 'vtex.render-runtime'
+import { Link, withRuntimeContext } from 'vtex.render-runtime'
 import OutsideClickHandler from 'react-outside-click-handler'
 import classNames from 'classnames'
 
@@ -20,7 +20,7 @@ const profileIcon = (iconSize, labelClasses, classes) => (
     <IconProfile size={iconSize} />
   </div>
 )
-export default class LoginComponent extends Component {
+class LoginComponent extends Component {
   static propTypes = LoginPropTypes
 
   /** Function called after login success */
@@ -40,6 +40,7 @@ export default class LoginComponent extends Component {
       renderIconAsLink,
       onProfileIconClick,
       data,
+      runtime: { history: { location: { pathname } } },
     } = this.props
     const profile = getProfile(data)
     const iconClasses = 'flex items-center'
@@ -64,9 +65,11 @@ export default class LoginComponent extends Component {
 
     if (renderIconAsLink) {
       const linkTo = profile ? 'store.account' : 'store.login'
+      const returnUrl = !profile && `returnUrl=${encodeURIComponent(pathname)}`
       return (
         <Link
           page={linkTo}
+          query={returnUrl}
           className={`${styles.buttonLink} h1 w2 tc flex items-center w-100-s h-100-s pa4-s`}
         >
           {iconContent}
@@ -121,3 +124,5 @@ export default class LoginComponent extends Component {
     )
   }
 }
+
+export default withRuntimeContext(LoginComponent)

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -40,6 +40,15 @@ export const LoginPropTypes = {
   onOutSideBoxClick: PropTypes.func.isRequired,
   /** Function called when the user clicks on the icon*/
   onProfileIconClick: PropTypes.func.isRequired,
+  /** Runtime context. */
+  runtime: PropTypes.shape({
+    history: PropTypes.shape({
+      location: PropTypes.shape({
+        pathname: PropTypes.string,
+        search: PropTypes.string,
+      }),
+    }),
+  }),
   /** Props received through the LoginContainer */
   ...LoginContainerProptypes,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix the user redirection after OAuth login from any page.
- Pass the returnURL QueryParam when the user go to `/login`.

#### What problem is this solving?
With this fix after the user do a OAuth login won't redirect to the Home page, else to the last page where he was.

#### How should this be manually tested?
[Workspace](https://vtexexito--prueba1.myvtex.com)
- If the user does a OAuth login it should to redirect to the last page where he was.
- In mobile version should to pass the QueryParam with the path of the last page when redirect to `/login`.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
