### PR TITLE
Auto-redirect to OAuth when there's only one provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.11.0] - 2019-05-16
+
 ### Added
 
 - Auto-redirect to OAuth when there's only one provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Auto-redirect to OAuth when there's only one provider.
+
 ## [2.10.1] - 2019-05-07
 ### Fixed
 - Fix error messages not appearing correctly

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/context.json
+++ b/messages/context.json
@@ -35,6 +35,7 @@
   "store/login.email.placeholder": "store/login.email.placeholder",
   "store/login.password.placeholder": "store/login.password.placeholder",
   "store/login.accessCode.placeholder": "store/login.accessCode.placeholder",
+  "store/login.autoRedirect.message": "store/login.autoRedirect.message",
   "admin/editor.login.isInitialScreenOptionOnly.title": "admin/editor.login.isInitialScreenOptionOnly.title",
   "admin/editor.login.defaultOption.title": "admin/editor.login.defaultOption.title",
   "admin/editor.login.defaultOption.token": "admin/editor.login.defaultOption.token",

--- a/messages/en.json
+++ b/messages/en.json
@@ -35,6 +35,7 @@
     "store/login.email.placeholder": "Ex.: example@mail.com",
     "store/login.password.placeholder": "Add your password",
     "store/login.accessCode.placeholder": "Add your access code",
+    "store/login.autoRedirect.message": "We are redirecting you to our {provider} login",
     "admin/editor.login.isInitialScreenOptionOnly.title": "Show only the login options on the initial screen",
     "admin/editor.login.defaultOption.title": "Initial form to show",
     "admin/editor.login.defaultOption.token": "Access code login",

--- a/messages/es.json
+++ b/messages/es.json
@@ -35,6 +35,7 @@
     "store/login.email.placeholder": "Ex.: example@mail.com",
     "store/login.password.placeholder": "Agrega tu contraseña",
     "store/login.accessCode.placeholder": "Agrega tu código de acceso",
+    "store/login.autoRedirect.message": "Te estamos redireccionando a nuestro login de {provider}",
     "admin/editor.login.isInitialScreenOptionOnly.title": "Mostrar sólo las opciones de inicio de sesión en la pantalla de inicio",
     "admin/editor.login.defaultOption.title": "Formulario inicial que se mostrará",
     "admin/editor.login.defaultOption.token": "Inicio de sesión por token",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -35,6 +35,7 @@
     "store/login.email.placeholder": "Ex.: example@mail.com",
     "store/login.password.placeholder": "Adicione sua senha",
     "store/login.accessCode.placeholder": "Adicione seu código de acesso",
+    "store/login.autoRedirect.message": "Estamos redirecionando você para o nosso login do {provider}",
     "admin/editor.login.isInitialScreenOptionOnly.title": "Mostrar apenas as opções de login na tela inicial",
     "admin/editor.login.defaultOption.title": "Formulário inicial a ser mostrado",
     "admin/editor.login.defaultOption.token": "Login por código de acesso",

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -33,7 +33,7 @@ const STEPS = [
   /* eslint-disable react/display-name, react/prop-types */
   (props, state, func, isOptionsMenuDisplayed) => {
     return style => (
-      <div style={style}>
+      <div style={style} key={0}>
         <EmailVerification
           next={steps.CODE_CONFIRMATION}
           previous={steps.LOGIN_OPTIONS}
@@ -48,7 +48,7 @@ const STEPS = [
   },
   (props, state, func, isOptionsMenuDisplayed) => {
     return style => (
-      <div style={style}>
+      <div style={style} key={1}>
         <EmailAndPassword
           next={steps.ACCOUNT_OPTIONS}
           previous={steps.LOGIN_OPTIONS}
@@ -67,7 +67,7 @@ const STEPS = [
   },
   (props, state, func) => {
     return style => (
-      <div style={style}>
+      <div style={style} key={2}>
         <CodeConfirmation
           next={steps.ACCOUNT_OPTIONS}
           previous={steps.EMAIL_VERIFICATION}
@@ -80,14 +80,14 @@ const STEPS = [
   },
   () => {
     return style => (
-      <div style={style}>
+      <div style={style} key={3}>
         <AccountOptions />
       </div>
     )
   },
   (props, state, func) => {
     return style => (
-      <div style={style}>
+      <div style={style} key={4}>
         <RecoveryPassword
           next={steps.ACCOUNT_OPTIONS}
           previous={steps.EMAIL_PASSWORD}
@@ -271,7 +271,7 @@ class LoginContent extends Component {
     }
     
     return (
-      <div style={style}>
+      <div style={style} key={0}>
         <AuthState.IdentityProviders>
           {({ value: options }) => {
             const [

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -184,7 +184,7 @@ class LoginContent extends Component {
     )
   }
 
-  shouldRedirectToOAuth = (loginOptions) => {
+  shouldRedirectToOAuth = loginOptions => {
     if (!loginOptions) return [false, null]
     const { accessKey, oAuthProviders, password } = loginOptions
     if (accessKey || password) return [false, null]

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -185,12 +185,11 @@ class LoginContent extends Component {
   }
 
   shouldRedirectToOAuth = (loginOptions) => {
-    if (!loginOptions) return false
+    if (!loginOptions) return [false, null]
     const { accessKey, oAuthProviders, password } = loginOptions
-    if (accessKey || password) return false
-    if (!oAuthProviders || oAuthProviders.length === 0) return false
-    if (oAuthProviders.length > 1) return false
-    return true
+    if (accessKey || password) return [false, null]
+    if (!oAuthProviders || oAuthProviders.length !== 1) return [false, null]
+    return [true, oAuthProviders[0]]
   }
 
   handleUpdateState = state => {
@@ -270,12 +269,13 @@ class LoginContent extends Component {
     } else if (isOnInitialScreen) {
       step = defaultOption
     }
+    const [shouldRedirectToOauth, oauthProvider] = this.shouldRedirectToOAuth(options)
     return (
       <div style={style}>
         <AuthState.IdentityProviders>
           {({ value: options }) =>
-            this.shouldRedirectToOAuth(options) ? (
-              <OAuthAutoRedirect provider={options.oAuthProviders[0].providerName} />
+            shouldRedirectToOauth && oauthProvider ? (
+              <OAuthAutoRedirect provider={oauthProvider.providerName} />
             ) : (
               <LoginOptions
                 page="login-options"

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -269,12 +269,16 @@ class LoginContent extends Component {
     } else if (isOnInitialScreen) {
       step = defaultOption
     }
-    const [shouldRedirectToOauth, oauthProvider] = this.shouldRedirectToOAuth(options)
+    
     return (
       <div style={style}>
         <AuthState.IdentityProviders>
-          {({ value: options }) =>
-            shouldRedirectToOauth && oauthProvider ? (
+          {({ value: options }) => {
+            const [
+              shouldRedirectToOauth,
+              oauthProvider,
+            ] = this.shouldRedirectToOAuth(options)
+            return shouldRedirectToOauth && oauthProvider ? (
               <OAuthAutoRedirect provider={oauthProvider.providerName} />
             ) : (
               <LoginOptions
@@ -296,7 +300,7 @@ class LoginContent extends Component {
                 refetchOptions={this.refetchOptions}
               />
             )
-          }
+          }}
         </AuthState.IdentityProviders>
       </div>
     )

--- a/react/__mocks__/vtex.react-vtexid.js
+++ b/react/__mocks__/vtex.react-vtexid.js
@@ -34,16 +34,28 @@ export const AuthService = {
     }),
 }
 
-export class AuthState extends Component {
-  static Token = ({ children }) =>
-    children({ value: 'value', setValue: () => {} })
-  static Password = ({ children }) =>
-    children({ value: 'value', setValue: () => {} })
-  static Email = ({ children }) =>
-    children({ value: 'value', setValue: () => {} })
+const AuthState = jest.fn(({ children }) => children({ loading: false }))
 
-  render() {
-    const { children } = this.props
-    return children()
-  }
-}
+AuthState.Token = jest.fn(({ children }) =>
+  children({ value: 'value', setValue: () => {} })
+)
+
+AuthState.Password = jest.fn(({ children }) =>
+  children({ value: 'value', setValue: () => {} })
+)
+
+AuthState.Email = jest.fn(({ children }) =>
+  children({ value: 'value', setValue: () => {} })
+)
+
+AuthState.IdentityProviders = jest.fn(({ children }) =>
+  children({
+    value: {
+      accessKey: true,
+      password: true,
+      oAuthProviders: [{ providerName: 'Google', className: '' }],
+    },
+  })
+)
+
+export { AuthState }

--- a/react/__mocks__/vtex.styleguide.js
+++ b/react/__mocks__/vtex.styleguide.js
@@ -12,3 +12,5 @@ export const ButtonWithIcon = ({ children }) => (
 )
 
 export const Input = props => <input {...props} />
+
+export const Spinner = () => <div className="spinner"></div>

--- a/react/__tests__/Login.test.js
+++ b/react/__tests__/Login.test.js
@@ -3,8 +3,12 @@ import { renderWithIntl } from 'intl-utils'
 
 import Login from '../Login'
 
+import { AuthState } from 'vtex.react-vtexid'
+
 describe('<Login /> component', () => {
   it('should match snapshot when loading', () => {
+    AuthState.mockImplementationOnce(({ children }) => children({ loading: true }))
+
     const { asFragment } = renderWithIntl(
       <Login
         isBoxOpen
@@ -14,6 +18,7 @@ describe('<Login /> component', () => {
         }}
       />
     )
+
     expect(asFragment()).toMatchSnapshot()
   })
 

--- a/react/__tests__/__snapshots__/Login.test.js.snap
+++ b/react/__tests__/__snapshots__/Login.test.js.snap
@@ -32,20 +32,15 @@ exports[`<Login /> component should match snapshot when loading 1`] = `
                 class="content flex relative bg-base justify-around overflow-visible pa4 center contentInitialScreen items-baseline"
               >
                 <div
-                  enter="[object Object]"
-                  from="[object Object]"
-                  keys=""
-                  leave="[object Object]"
-                />
-                <div
-                  class="contentForm dn ph4 pb6"
+                  class="loading"
                 >
                   <div
-                    enter="[object Object]"
-                    from="[object Object]"
-                    keys=""
-                    leave="[object Object]"
-                  />
+                    class="w-100 tc c-emphasis pv8"
+                  >
+                    <div
+                      class="spinner"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -326,21 +321,82 @@ exports[`<Login /> component should match snapshot without profile 1`] = `
                           class="optionsListItem mb3"
                         >
                           <div
-                            class="button buttonDanger"
+                            class="button"
                           >
                             <button
                               class="Button-mock"
                               type="button"
                             >
-                              <div
-                                class="db"
+                              <span>
+                                Receive access code by email
+                              </span>
+                            </button>
+                          </div>
+                        </li>
+                        <li
+                          class="optionsListItem mb3"
+                        >
+                          <div
+                            class="button"
+                          >
+                            <button
+                              class="Button-mock"
+                              type="button"
+                            >
+                              <span>
+                                Sign in with email and password
+                              </span>
+                            </button>
+                          </div>
+                        </li>
+                        <li
+                          class="optionsListItem mb3"
+                        >
+                          <div
+                            class="button buttonSocial"
+                          >
+                            <button
+                              class="Button-mock"
+                              type="button"
+                            >
+                              <svg
+                                height="20"
+                                viewBox="0 0 48 48"
+                                width="20"
+                                x="0px"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0px"
                               >
-                                Something bad happened...
-                              </div>
+                                <g
+                                  id="surface1"
+                                >
+                                  <path
+                                    d="M 43.609375 20.082031 L 42 20.082031 L 42 20 L 24 20 L 24 28 L 35.304688 28 C 33.652344 32.65625 29.222656 36 24 36 C 17.371094 36 12 30.628906 12 24 C 12 17.371094 17.371094 12 24 12 C 27.058594 12 29.84375 13.152344 31.960938 15.039063 L 37.617188 9.382813 C 34.046875 6.054688 29.269531 4 24 4 C 12.953125 4 4 12.953125 4 24 C 4 35.046875 12.953125 44 24 44 C 35.046875 44 44 35.046875 44 24 C 44 22.660156 43.863281 21.351563 43.609375 20.082031 Z "
+                                    style="fill: #FFC107;"
+                                  />
+                                  <path
+                                    d="M 6.304688 14.691406 L 12.878906 19.511719 C 14.65625 15.109375 18.960938 12 24 12 C 27.058594 12 29.84375 13.152344 31.960938 15.039063 L 37.617188 9.382813 C 34.046875 6.054688 29.269531 4 24 4 C 16.316406 4 9.65625 8.335938 6.304688 14.691406 Z "
+                                    style="fill: #FF3D00;"
+                                  />
+                                  <path
+                                    d="M 24 44 C 29.164063 44 33.859375 42.023438 37.410156 38.808594 L 31.21875 33.570313 C 29.210938 35.089844 26.714844 36 24 36 C 18.796875 36 14.382813 32.683594 12.71875 28.054688 L 6.195313 33.078125 C 9.503906 39.554688 16.226563 44 24 44 Z "
+                                    style="fill: #4CAF50;"
+                                  />
+                                  <path
+                                    d="M 43.609375 20.082031 L 42 20.082031 L 42 20 L 24 20 L 24 28 L 35.304688 28 C 34.511719 30.238281 33.070313 32.164063 31.214844 33.570313 C 31.21875 33.570313 31.21875 33.570313 31.21875 33.570313 L 37.410156 38.808594 C 36.972656 39.203125 44 34 44 24 C 44 22.660156 43.863281 21.351563 43.609375 20.082031 Z "
+                                    style="fill: #1976D2;"
+                                  />
+                                </g>
+                              </svg>
                               <span
-                                class="t-small pt1"
+                                class="t-action--small oauthLabel relative normal"
                               >
-                                Click to try again.
+                                Sign in with
+                                <span
+                                  class="oauthProvider b ml2"
+                                >
+                                  Google
+                                </span>
                               </span>
                             </button>
                           </div>

--- a/react/__tests__/__snapshots__/LoginContent.test.js.snap
+++ b/react/__tests__/__snapshots__/LoginContent.test.js.snap
@@ -29,21 +29,82 @@ exports[`<LoginContent /> component should match snapshot 1`] = `
               class="optionsListItem mb3"
             >
               <div
-                class="button buttonDanger"
+                class="button"
               >
                 <button
                   class="Button-mock"
                   type="button"
                 >
-                  <div
-                    class="db"
+                  <span>
+                    Receive access code by email
+                  </span>
+                </button>
+              </div>
+            </li>
+            <li
+              class="optionsListItem mb3"
+            >
+              <div
+                class="button"
+              >
+                <button
+                  class="Button-mock"
+                  type="button"
+                >
+                  <span>
+                    Sign in with email and password
+                  </span>
+                </button>
+              </div>
+            </li>
+            <li
+              class="optionsListItem mb3"
+            >
+              <div
+                class="button buttonSocial"
+              >
+                <button
+                  class="Button-mock"
+                  type="button"
+                >
+                  <svg
+                    height="20"
+                    viewBox="0 0 48 48"
+                    width="20"
+                    x="0px"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0px"
                   >
-                    Something bad happened...
-                  </div>
+                    <g
+                      id="surface1"
+                    >
+                      <path
+                        d="M 43.609375 20.082031 L 42 20.082031 L 42 20 L 24 20 L 24 28 L 35.304688 28 C 33.652344 32.65625 29.222656 36 24 36 C 17.371094 36 12 30.628906 12 24 C 12 17.371094 17.371094 12 24 12 C 27.058594 12 29.84375 13.152344 31.960938 15.039063 L 37.617188 9.382813 C 34.046875 6.054688 29.269531 4 24 4 C 12.953125 4 4 12.953125 4 24 C 4 35.046875 12.953125 44 24 44 C 35.046875 44 44 35.046875 44 24 C 44 22.660156 43.863281 21.351563 43.609375 20.082031 Z "
+                        style="fill: #FFC107;"
+                      />
+                      <path
+                        d="M 6.304688 14.691406 L 12.878906 19.511719 C 14.65625 15.109375 18.960938 12 24 12 C 27.058594 12 29.84375 13.152344 31.960938 15.039063 L 37.617188 9.382813 C 34.046875 6.054688 29.269531 4 24 4 C 16.316406 4 9.65625 8.335938 6.304688 14.691406 Z "
+                        style="fill: #FF3D00;"
+                      />
+                      <path
+                        d="M 24 44 C 29.164063 44 33.859375 42.023438 37.410156 38.808594 L 31.21875 33.570313 C 29.210938 35.089844 26.714844 36 24 36 C 18.796875 36 14.382813 32.683594 12.71875 28.054688 L 6.195313 33.078125 C 9.503906 39.554688 16.226563 44 24 44 Z "
+                        style="fill: #4CAF50;"
+                      />
+                      <path
+                        d="M 43.609375 20.082031 L 42 20.082031 L 42 20 L 24 20 L 24 28 L 35.304688 28 C 34.511719 30.238281 33.070313 32.164063 31.214844 33.570313 C 31.21875 33.570313 31.21875 33.570313 31.21875 33.570313 L 37.410156 38.808594 C 36.972656 39.203125 44 34 44 24 C 44 22.660156 43.863281 21.351563 43.609375 20.082031 Z "
+                        style="fill: #1976D2;"
+                      />
+                    </g>
+                  </svg>
                   <span
-                    class="t-small pt1"
+                    class="t-action--small oauthLabel relative normal"
                   >
-                    Click to try again.
+                    Sign in with
+                    <span
+                      class="oauthProvider b ml2"
+                    >
+                      Google
+                    </span>
                   </span>
                 </button>
               </div>
@@ -83,9 +144,120 @@ exports[`<LoginContent /> component should match snapshot when loading 1`] = `
     <div
       enter="[object Object]"
       from="[object Object]"
-      keys=""
+      keys="children"
       leave="[object Object]"
-    />
+    >
+      <div
+        style="opacity: 0; transform: translateX(-50%);"
+      >
+        <div
+          class="options"
+        >
+          <h3
+            class="formTitle t-body v-mid ttu tc relative pv2 ph3 br2"
+          >
+            Choose an option to sign in
+          </h3>
+          <ul
+            class="optionsList list pa0"
+          >
+            <li
+              class="optionsListItem mb3"
+            >
+              <div
+                class="button"
+              >
+                <button
+                  class="Button-mock"
+                  type="button"
+                >
+                  <span>
+                    Receive access code by email
+                  </span>
+                </button>
+              </div>
+            </li>
+            <li
+              class="optionsListItem mb3"
+            >
+              <div
+                class="button"
+              >
+                <button
+                  class="Button-mock"
+                  type="button"
+                >
+                  <span>
+                    Sign in with email and password
+                  </span>
+                </button>
+              </div>
+            </li>
+            <li
+              class="optionsListItem mb3"
+            >
+              <div
+                class="button buttonSocial"
+              >
+                <button
+                  class="Button-mock"
+                  type="button"
+                >
+                  <svg
+                    height="20"
+                    viewBox="0 0 48 48"
+                    width="20"
+                    x="0px"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0px"
+                  >
+                    <g
+                      id="surface1"
+                    >
+                      <path
+                        d="M 43.609375 20.082031 L 42 20.082031 L 42 20 L 24 20 L 24 28 L 35.304688 28 C 33.652344 32.65625 29.222656 36 24 36 C 17.371094 36 12 30.628906 12 24 C 12 17.371094 17.371094 12 24 12 C 27.058594 12 29.84375 13.152344 31.960938 15.039063 L 37.617188 9.382813 C 34.046875 6.054688 29.269531 4 24 4 C 12.953125 4 4 12.953125 4 24 C 4 35.046875 12.953125 44 24 44 C 35.046875 44 44 35.046875 44 24 C 44 22.660156 43.863281 21.351563 43.609375 20.082031 Z "
+                        style="fill: #FFC107;"
+                      />
+                      <path
+                        d="M 6.304688 14.691406 L 12.878906 19.511719 C 14.65625 15.109375 18.960938 12 24 12 C 27.058594 12 29.84375 13.152344 31.960938 15.039063 L 37.617188 9.382813 C 34.046875 6.054688 29.269531 4 24 4 C 16.316406 4 9.65625 8.335938 6.304688 14.691406 Z "
+                        style="fill: #FF3D00;"
+                      />
+                      <path
+                        d="M 24 44 C 29.164063 44 33.859375 42.023438 37.410156 38.808594 L 31.21875 33.570313 C 29.210938 35.089844 26.714844 36 24 36 C 18.796875 36 14.382813 32.683594 12.71875 28.054688 L 6.195313 33.078125 C 9.503906 39.554688 16.226563 44 24 44 Z "
+                        style="fill: #4CAF50;"
+                      />
+                      <path
+                        d="M 43.609375 20.082031 L 42 20.082031 L 42 20 L 24 20 L 24 28 L 35.304688 28 C 34.511719 30.238281 33.070313 32.164063 31.214844 33.570313 C 31.21875 33.570313 31.21875 33.570313 31.21875 33.570313 L 37.410156 38.808594 C 36.972656 39.203125 44 34 44 24 C 44 22.660156 43.863281 21.351563 43.609375 20.082031 Z "
+                        style="fill: #1976D2;"
+                      />
+                    </g>
+                  </svg>
+                  <span
+                    class="t-action--small oauthLabel relative normal"
+                  >
+                    Sign in with
+                    <span
+                      class="oauthProvider b ml2"
+                    >
+                      Google
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </li>
+            <li
+              class="optionsListItem optionsListItemContainer mb3"
+            >
+              <div
+                class="ExtensionContainer-mock"
+              >
+                container
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
     <div
       class="contentForm dn ph4 pb6"
     >

--- a/react/components/Loading.js
+++ b/react/components/Loading.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Spinner } from 'vtex.styleguide'
+
+function Loading() {
+  return (
+    <div className="w-100 tc c-emphasis pv8">
+      <Spinner color="currentColor" size={32} />
+    </div>
+  )
+}
+
+export default Loading

--- a/react/components/Loading.js
+++ b/react/components/Loading.js
@@ -1,10 +1,14 @@
 import React from 'react'
 import { Spinner } from 'vtex.styleguide'
 
+import styles from '../styles.css'
+
 function Loading() {
   return (
-    <div className="w-100 tc c-emphasis pv8">
-      <Spinner color="currentColor" size={32} />
+    <div className={styles.loading}>
+      <div className="w-100 tc c-emphasis pv8">
+        <Spinner color="currentColor" size={32} />
+      </div>
     </div>
   )
 }

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
 import { ExtensionContainer } from 'vtex.render-runtime'
 
@@ -62,45 +62,47 @@ class LoginOptions extends Component {
       <div className={classes}>
         <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
         <ul className={`${styles.optionsList} list pa0`}>
-          {this.showOption('accessKeyAuthentication', 'store/loginOptions.emailVerification') &&
-            <li className={`${styles.optionsListItem} mb3`}>
-              <div className={styles.button}>
-                <Button
-                  variation="secondary"
-                  onClick={this.handleOptionClick('store/loginOptions.emailVerification')}
-                >
-                  <span>{translate('store/loginOptions.emailVerification', intl)}</span>
-                </Button>
-              </div>
-            </li>
-          }
-          {this.showOption('classicAuthentication', 'store/loginOptions.emailAndPassword') &&
-            <li className={`${styles.optionsListItem} mb3`}>
-              <div className={styles.button}>
-                <Button
-                  variation="secondary"
-                  onClick={this.handleOptionClick('store/loginOptions.emailAndPassword')}
-                >
-                  <span>{translate('store/loginOptions.emailAndPassword', intl)}</span>
-                </Button>
-              </div>
-            </li>
-          }
-          {options && options.providers && options.providers.map(({ providerName }, index) => {
-            const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
-
-            return (
-              <li
-                className={`${styles.optionsListItem} mb3`}
-                key={`${providerName}-${index}`}
-              >
-                <OAuth provider={providerName}>
-                  {hasIcon ? React.createElement(PROVIDERS_ICONS[providerName], null) : null}
-                </OAuth>
-              </li>
-            )
-          })}
-          {!options && (
+          {options ? (
+            <Fragment>
+              {options.accessKeyAuthentication && this.showOption('accessKeyAuthentication', 'store/loginOptions.emailVerification') &&
+                <li className={`${styles.optionsListItem} mb3`}>
+                  <div className={styles.button}>
+                    <Button
+                      variation="secondary"
+                      onClick={this.handleOptionClick('store/loginOptions.emailVerification')}
+                    >
+                      <span>{translate('store/loginOptions.emailVerification', intl)}</span>
+                    </Button>
+                  </div>
+                </li>
+              }
+              {options.classicAuthentication && this.showOption('classicAuthentication', 'store/loginOptions.emailAndPassword') &&
+                <li className={`${styles.optionsListItem} mb3`}>
+                  <div className={styles.button}>
+                    <Button
+                      variation="secondary"
+                      onClick={this.handleOptionClick('store/loginOptions.emailAndPassword')}
+                    >
+                      <span>{translate('store/loginOptions.emailAndPassword', intl)}</span>
+                    </Button>
+                  </div>
+                </li>
+              }
+              {options.providers && options.providers.map(({ providerName }, index) => {
+                const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
+                return (
+                  <li
+                    className={`${styles.optionsListItem} mb3`}
+                    key={`${providerName}-${index}`}
+                  >
+                    <OAuth provider={providerName}>
+                      {hasIcon ? React.createElement(PROVIDERS_ICONS[providerName], null) : null}
+                    </OAuth>
+                  </li>
+                )
+              })}
+            </Fragment>
+          ) : (
             <li className={`${styles.optionsListItem} mb3`}>
               <div className={`${styles.button} ${styles.buttonDanger}`}>
                 <Button

--- a/react/components/OAuthAutoRedirect.js
+++ b/react/components/OAuthAutoRedirect.js
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { injectIntl, intlShape } from 'react-intl'
+import { Spinner } from 'vtex.styleguide'
+import { AuthService } from 'vtex.react-vtexid'
+
+function OAuthAutoRedirect({ intl, provider, redirect }) {
+  useEffect(() => {
+    redirect()
+  }, [])
+  return (
+    <div className="w-100 flex flex-column pv5">
+      <p className="tc ph4">
+        {intl.formatMessage(
+          {
+            id: 'store/login.autoRedirect.message',
+          },
+          { provider }
+        )}
+      </p>
+      <div className="self-center c-emphasis">
+        <Spinner color="currentColor" size={24} />
+      </div>
+    </div>
+  )
+}
+OAuthAutoRedirect.propTypes = {
+  redirect: PropTypes.func.isRequired,
+  provider: PropTypes.string.isRequired,
+  loading: PropTypes.bool,
+  intl: intlShape,
+}
+
+function Wrapper({ provider, ...props }) {
+  return (
+    <AuthService.OAuthRedirect useNewSession provider={provider}>
+      {({ loading, action: redirectToOAuthPage }) => (
+        <OAuthAutoRedirect
+          {...props}
+          loading={loading}
+          provider={provider}
+          redirect={redirectToOAuthPage}
+        />
+      )}
+    </AuthService.OAuthRedirect>
+  )
+}
+Wrapper.propTypes = {
+  provider: PropTypes.string.isRequired,
+}
+
+export default injectIntl(Wrapper)

--- a/react/components/OAuthAutoRedirect.js
+++ b/react/components/OAuthAutoRedirect.js
@@ -21,7 +21,7 @@ function OAuthAutoRedirect({ intl, provider, redirect }) {
             { provider }
           )}
         </p>
-        <div className="self-center c-emphasis">
+        <div className={`self-center c-emphasis ${styles.oauthAutoRedirectLoading}`}>
           <Spinner color="currentColor" size={24} />
         </div>
       </div>

--- a/react/components/OAuthAutoRedirect.js
+++ b/react/components/OAuthAutoRedirect.js
@@ -4,22 +4,26 @@ import { injectIntl, intlShape } from 'react-intl'
 import { Spinner } from 'vtex.styleguide'
 import { AuthService } from 'vtex.react-vtexid'
 
+import styles from '../styles.css'
+
 function OAuthAutoRedirect({ intl, provider, redirect }) {
   useEffect(() => {
     redirect()
   }, [])
   return (
-    <div className="w-100 flex flex-column pv5">
-      <p className="tc ph4">
-        {intl.formatMessage(
-          {
-            id: 'store/login.autoRedirect.message',
-          },
-          { provider }
-        )}
-      </p>
-      <div className="self-center c-emphasis">
-        <Spinner color="currentColor" size={24} />
+    <div className={styles.oauthAutoRedirect}>
+      <div className="w-100 flex flex-column pv5">
+        <p className="tc ph4">
+          {intl.formatMessage(
+            {
+              id: 'store/login.autoRedirect.message',
+            },
+            { provider }
+          )}
+        </p>
+        <div className="self-center c-emphasis">
+          <Spinner color="currentColor" size={24} />
+        </div>
       </div>
     </div>
   )

--- a/react/styles.css
+++ b/react/styles.css
@@ -22,6 +22,8 @@
 
 .oauthAutoRedirect {}
 
+.oauthAutoRedirectLoading {}
+
 .inputContainer {}
 
 .inputContainerAccessCode {}

--- a/react/styles.css
+++ b/react/styles.css
@@ -8,6 +8,8 @@
 
 .label {}
 
+.loading {}
+
 .optionsSticky {}
 
 .optionsList {}
@@ -17,6 +19,8 @@
 .optionsListItemContainer {}
 
 .oauthProvider {}
+
+.oauthAutoRedirect {}
 
 .inputContainer {}
 
@@ -90,9 +94,9 @@
 }
 
 .sendButton:only-child {
-    margin: 0;
-    width: 100%;
-  }
+  margin: 0;
+  width: 100%;
+}
 
 .sendButton:only-child :global(.vtex-button) {
   width: 100%;


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds an auto-redirect to an OAuth provider when it is the only login option available for the store. It does it by replacing the `<LoginOptions />` component and informing the user he/she is being redirected to an external site.

>Note: The best use of this functionality is achieved when the store theme is also configured to hide the login form in the Login Page by setting the prop `isInitialScreenOptionOnly` to true.

This PR also adds a loading component to the login options.

#### What problem is this solving?
Some stores want to have a cross-site login using our built-in OAuth solution. In order to improve the user experience, they don't the user to have to open the login modal or page and then click on the OAuth provider option. They would like to be automatic.

#### How should this be manually tested?
To test the app with the redirect, go to [parceiro01's home](https://bezerra--parceiro01.myvtex.com/) or [parceiro01's login page](https://bezerra--parceiro01.myvtex.com/login). This account has only facebook enabled and should redirect you there.
To test the app without the redirect, goto [storecomponents's home](https://bezerra--storecomponents.myvtex.com/) or [storecomponents's login page](https://bezerra--storecomponents.myvtex.com/login). This account has more than one OAuth provider, and *should not* redirect you.


#### Screenshots or example usage
##### Login Modal (Home page) Before 
![oauth-redirect-home-before](https://user-images.githubusercontent.com/8474847/57702430-71bb7b80-7634-11e9-9e3e-91751c0cf820.gif)
##### Login Modal (Home page) After
![oauth-redirect-home-after](https://user-images.githubusercontent.com/8474847/57702484-9283d100-7634-11e9-9e43-cfb9c03d020d.gif)

##### Login Page Before 
![oauth-redirect-login-2-before](https://user-images.githubusercontent.com/8474847/57702594-c828ba00-7634-11e9-8aa4-672009fc9261.gif)
##### Login Page After 
![oauth-redirect-login-2-after](https://user-images.githubusercontent.com/8474847/57702613-d2e34f00-7634-11e9-89ad-43b4fb0446c0.gif)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
