### PR TITLE
disable password verification hint on login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove password verification from login.
 
 ## [2.13.1] - 2019-05-23
 ### Fixed 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,6 @@
     "vtex.store-icons": "0.x",
     "vtex.react-vtexid": "4.x",
     "vtex.react-portal": "0.x"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/EmailAndPassword.js
+++ b/react/components/EmailAndPassword.js
@@ -92,7 +92,6 @@ class EmailAndPassword extends Component {
       showBackButton,
       emailPlaceholder,
       passwordPlaceholder,
-      showPasswordVerificationIntoTooltip,
     } = this.props
 
     const {
@@ -141,9 +140,7 @@ class EmailAndPassword extends Component {
                       passwordPlaceholder ||
                       translate('store/login.password.placeholder', intl)
                     }
-                    showPasswordVerificationIntoTooltip={
-                      showPasswordVerificationIntoTooltip
-                    }
+                    disablePasswordVerification="true"
                   />
                 )}
               </AuthState.Password>
@@ -190,22 +187,22 @@ class EmailAndPassword extends Component {
                   action: loginWithPassword,
                   validation: { validateEmail },
                 }) => (
-                    <Button
-                      variation="primary"
-                      size="small"
-                      type="submit"
-                      onClick={e => {
-                        e.preventDefault()
-                        this.handleOnSubmit(email, password, loginWithPassword)
-                      }}
-                      isLoading={loading}
-                      disabled={!validateEmail(email)}
-                    >
-                      <span className="t-small">
-                        {translate('store/login.signIn', intl)}
-                      </span>
-                    </Button>
-                  )}
+                  <Button
+                    variation="primary"
+                    size="small"
+                    type="submit"
+                    onClick={e => {
+                      e.preventDefault()
+                      this.handleOnSubmit(email, password, loginWithPassword)
+                    }}
+                    isLoading={loading}
+                    disabled={!validateEmail(email)}
+                  >
+                    <span className="t-small">
+                      {translate('store/login.signIn', intl)}
+                    </span>
+                  </Button>
+                )}
               </AuthService.LoginWithPassword>
             </div>
           </Fragment>

--- a/react/components/PasswordInput.js
+++ b/react/components/PasswordInput.js
@@ -58,7 +58,7 @@ class PasswordInput extends Component {
       showPassword,
     } = this.state
 
-    const { intl, password, showPasswordVerificationIntoTooltip } = this.props
+    const { intl, password, showPasswordVerificationIntoTooltip, disablePasswordVerification } = this.props
 
     const fields = [
       {
@@ -98,7 +98,7 @@ class PasswordInput extends Component {
             translate('store/login.password.placeholder', intl)
           }
           onBlur={() => this.setState({ showVerification: false })}
-          onFocus={() => this.setState({ showVerification: true })}
+          onFocus={() => this.setState({ showVerification: !disablePasswordVerification })}
           suffixIcon={
             <span className="pointer" onClick={this.handleEyeIcon}>
               <IconEyeSight
@@ -129,6 +129,8 @@ PasswordInput.propTypes = {
   placeholder: PropTypes.string.isRequired,
   /** Set the type of password verification ui */
   showPasswordVerificationIntoTooltip: PropTypes.bool,
+  /** Disable password verification on ui */
+  disablePasswordVerification: PropTypes.bool,
   /** Function to change de active tab */
   onStateChange: PropTypes.func.isRequired,
   /** Intl object*/


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Create a new prop into `PasswordInput` component to hide the password check and use it on `EmailAndPassword` component for this purpose.
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
![Jun-17-2019 11-12-43](https://user-images.githubusercontent.com/12215291/59611619-fd23a300-90f1-11e9-8fb5-30e16506e2ae.gif)
When the password input loses focus, the verification is hidden and the Sign In button goes up, making the user miss click the button.
#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/12215291/59611812-69060b80-90f2-11e9-93c4-8fdc870173f9.png)
Since this is a login component, a password hint does not make sense, so removing the verification did the trick.
#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
