### PR TITLE
make password verification hint fixed after it was shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make password verification fixed after it was shown
 
 ## [2.13.1] - 2019-05-23
 ### Fixed 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,6 @@
     "vtex.store-icons": "0.x",
     "vtex.react-vtexid": "4.x",
     "vtex.react-portal": "0.x"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/PasswordInput.js
+++ b/react/components/PasswordInput.js
@@ -97,7 +97,7 @@ class PasswordInput extends Component {
             this.props.placeholder ||
             translate('store/login.password.placeholder', intl)
           }
-          onBlur={() => this.setState({ showVerification: false })}
+          onBlur={() => this.setState({ showVerification: !showPasswordVerificationIntoTooltip })}
           onFocus={() => this.setState({ showVerification: true })}
           suffixIcon={
             <span className="pointer" onClick={this.handleEyeIcon}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Changed the onBlur event of password input to only fade the verification hint when it is a tooltip.
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
![Jun-17-2019 11-12-43](https://user-images.githubusercontent.com/12215291/59615715-64912100-90f9-11e9-9eca-563969353dbb.gif)
When the password input loses focus, the verification is hidden and the Sign In button goes up, making the user miss click the button.

#### Screenshots or example usage
![fixed2](https://user-images.githubusercontent.com/12215291/59615963-dff2d280-90f9-11e9-9c5e-605b9b5ccc91.gif)
Making the verification fixed, the user doesn't miss the button anymore.
#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
