### PR TITLE
Fix/ch13006/session no cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- App considered user logged in even after his or her session expired
 
 ## [2.13.5] - 2019-06-27
 ### Fixed

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -389,7 +389,7 @@ class LoginContent extends Component {
   }
 }
 
-const options = {
+const config = {
   name: 'session',
   options: () => ({ ssr: false }),
 }
@@ -398,7 +398,7 @@ const content = withSession()(
   compose(
     injectIntl,
     graphql(LOGIN_OPTIONS_QUERY),
-    graphql(session, options)
+    graphql(session, config)
   )(LoginContent)
 )
 

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -391,7 +391,7 @@ class LoginContent extends Component {
 
 const config = {
   name: 'session',
-  options: () => ({ ssr: false }),
+  options: () => ({ ssr: false, fetchPolicy: 'no-cache' }),
 }
 
 const content = withSession()(


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the infinite redirect loop described in `https://app.clubhouse.io/vtex-dev/story/13006/login-com-loop-infinito`.

#### What problem is this solving?
When a user previously logged in had his session expired (expired cookie), the apollo cache still kept his profile. For that reason, when another app's Profile challenge fails (such as myAccount's challenge shown in the clubhouse story), redirecting the user to login would redirect him back. That happens because `login` didn't know the user session expired and acted as he was still logged in.

#### How should this be manually tested?
Please proceed to
`https://rafaprtest--storecomponents.myvtex.com/`
Then, log in to the store through any provider you prefer:

![image](https://user-images.githubusercontent.com/22064061/60300479-7d71b180-9905-11e9-84ad-1f0e827dacea.png)

Then, delete the `vtex_session` cookie and click `My Account`.

![image](https://user-images.githubusercontent.com/22064061/60300614-bca00280-9905-11e9-9814-00fdccca10ad.png)

Instead of getting stuck in an endless redirect loop, `My Account` should correctly redirect you to the login page.

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
