### PR TITLE
Skip request when user is recognized

### DIFF
--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -371,7 +371,7 @@ class LoginContent extends Component {
       [`${styles.contentFormVisible} db `]: this.shouldRenderForm,
     })
     return (
-      <AuthState scope="STORE" returnUrl={this.returnUrl}>
+      <AuthState skip={!!profile} scope="STORE" returnUrl={this.returnUrl}>
         {({ loading }) => (
           <div className={className}>
             {loading ? (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove unnecessary request that happened sometimes

#### What problem is this solving?
When the login component is loaded, it makes a request to VtexId to get all Identity Providers. This is necessary to show all login options to the user, but it is not needed when the user is already logged in. This skips that request when the user is recognized.

#### How should this be manually tested?

Go into
https://rafaprtest--storecomponents.myvtex.com/
and log in as a store user.
Then, while at the home screen, open your DevTools, network tab.
Clean all the requests, then click the login component:
![image](https://user-images.githubusercontent.com/22064061/62579828-256e8900-b87b-11e9-94cd-43095cd75622.png)
In your DevTools, one or more requests will appear, but there will be no request to
`/api/vtexid/pub/authentication/providers`

If you do the same in
https://storecomponents.myvtex.com/
You will see that this request would happen if it wasn't for this change. Evidence:
![image](https://user-images.githubusercontent.com/22064061/62579890-4f27b000-b87b-11e9-8a9f-82515c2cdf7b.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
