### PR TITLE
Chore/session

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove call to getSession in first component, use sessionPromise from render.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Remove call to getSession in first component, use sessionPromise from render.
+- Remove call to `getSession` in first component, use sessionPromise from render.
 
 ### Fixed
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,8 +3,6 @@
   "store/loginOptions.emailVerification": "store/loginOptions.emailVerification",
   "store/loginOptions.emailAndPassword": "store/loginOptions.emailAndPassword",
   "store/loginOptions.oAuth": "store/loginOptions.oAuth",
-  "store/loginOptions.error.title": "store/loginOptions.error.title",
-  "store/loginOptions.error.subhead": "store/loginOptions.error.subhead",
   "store/login.goBack": "store/login.goBack",
   "store/login.send": "store/login.send",
   "store/login.create": "store/login.create",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,8 +3,6 @@
   "store/loginOptions.emailVerification": "Receive access code by e-mail",
   "store/loginOptions.emailAndPassword": "Sign in with e-mail and password",
   "store/loginOptions.oAuth": "Sign in with",
-  "store/loginOptions.error.title": "An unknown error has occurred.",
-  "store/loginOptions.error.subhead": "Click to retry.",
   "store/login.goBack": "Go back",
   "store/login.send": "Send",
   "store/login.create": "Create",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,8 +3,6 @@
   "store/loginOptions.emailVerification": "Recibir código de acceso por e-mail",
   "store/loginOptions.emailAndPassword": "Entrar con e-mail y contraseña",
   "store/loginOptions.oAuth": "Entrar con",
-  "store/loginOptions.error.title": "Se produjo un error desconocido",
-  "store/loginOptions.error.subhead": "Haga clic para intentar nuevamente.",
   "store/login.goBack": "Volver",
   "store/login.send": "Enviar",
   "store/login.create": "Crear",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,8 +3,6 @@
   "store/loginOptions.emailVerification": "Receber código de acesso por e-mail",
   "store/loginOptions.emailAndPassword": "Entrar com e-mail e senha",
   "store/loginOptions.oAuth": "Entrar com",
-  "store/loginOptions.error.title": "Ocorreu um erro desconhecido.",
-  "store/loginOptions.error.subhead": "Clique para tentar novamente.",
   "store/login.goBack": "Voltar",
   "store/login.send": "Enviar",
   "store/login.create": "Criar",

--- a/react/Login.js
+++ b/react/Login.js
@@ -27,16 +27,10 @@ export default class Login extends Component {
     sessionProfile: null,
   }
 
-  getSessionPromiseFromWindow = () => {
-    if (
-      !window.__RENDER_8_SESSION__ ||
-      !window.__RENDER_8_SESSION__.sessionPromise
-    ) {
-      return Promise.resolve(null)
-    }
-
-    return window.__RENDER_8_SESSION__.sessionPromise
-  }
+  getSessionPromiseFromWindow = () =>
+    !window.__RENDER_8_SESSION__ || !window.__RENDER_8_SESSION__.sessionPromise
+      ? Promise.resolve(null)
+      : window.__RENDER_8_SESSION__.sessionPromise
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize)
@@ -48,7 +42,8 @@ export default class Login extends Component {
 
     this.getSessionPromiseFromWindow().then(data => {
       const sessionResponse = (data || {}).response
-      this.setState({resp: data, sessionProfile: getProfile(sessionResponse) })
+      const sessionProfile = getProfile(sessionResponse)
+      if (sessionProfile) this.setState({ sessionProfile })
     })
   }
 

--- a/react/Login.js
+++ b/react/Login.js
@@ -25,7 +25,6 @@ export default class Login extends Component {
     isBoxOpen: false,
     renderIconAsLink: false,
     sessionProfile: null,
-    resp: "FOO",
   }
 
   componentDidMount() {

--- a/react/Login.js
+++ b/react/Login.js
@@ -8,6 +8,7 @@ import { setCookie } from './utils/set-cookie'
 import { LoginContainerProptypes } from './propTypes'
 import LoginComponent from './components/LoginComponent'
 import Loading from './components/Loading'
+import { getProfile } from './utils/profile'
 
 const DEFAULT_CLASSES = 'gray'
 
@@ -24,6 +25,7 @@ export default class Login extends Component {
     isBoxOpen: false,
     renderIconAsLink: false,
     sessionProfile: null,
+    resp: "FOO",
   }
 
   componentDidMount() {
@@ -34,36 +36,16 @@ export default class Login extends Component {
       setCookie(location.href)
     }
 
-    if (!window.__RENDER_8_SESSION__ || !window.__RENDER_8_SESSION__.sessionPromise) {
+    if (
+      !window.__RENDER_8_SESSION__ ||
+      !window.__RENDER_8_SESSION__.sessionPromise
+    ) {
       return
     }
 
     window.__RENDER_8_SESSION__.sessionPromise.then(data => {
       const sessionResponse = (data || {}).response
-
-      if (!sessionResponse || !sessionResponse.namespaces) {
-        return
-      }
-
-      const { namespaces: { profile } = {} } = sessionResponse
-      if (!profile) {
-        return
-      }
-
-      const {
-        email: { value: email } = { value: null },
-        firstName: { value: firstName } = { value: null },
-      } = profile
-
-      if (!email) {
-        return
-      }
-
-      const sessionProfile = {
-        email,
-        firstName,
-      }
-      this.setState({ sessionProfile })
+      this.setState({resp: data, sessionProfile: getProfile(sessionResponse) })
     })
   }
 

--- a/react/Login.js
+++ b/react/Login.js
@@ -38,13 +38,13 @@ export default class Login extends Component {
     }
 
     window.__RENDER_8_SESSION__.sessionPromise.then(data => {
-      const sessionRespose = data.response
+      const sessionResponse = data.response
 
-      if (!sessionRespose || !sessionRespose.namespaces) {
+      if (!sessionResponse || !sessionResponse.namespaces) {
         return
       }
 
-      const { namespaces } = sessionRespose
+      const { namespaces } = sessionResponse
       const storeUserId = path(
         ['authentication', 'storeUserId', 'value'],
         namespaces

--- a/react/Login.js
+++ b/react/Login.js
@@ -27,6 +27,17 @@ export default class Login extends Component {
     sessionProfile: null,
   }
 
+  getSessionPromiseFromWindow = () => {
+    if (
+      !window.__RENDER_8_SESSION__ ||
+      !window.__RENDER_8_SESSION__.sessionPromise
+    ) {
+      return Promise.resolve(null)
+    }
+
+    return window.__RENDER_8_SESSION__.sessionPromise
+  }
+
   componentDidMount() {
     window.addEventListener('resize', this.handleResize)
     this.handleResize()
@@ -35,14 +46,7 @@ export default class Login extends Component {
       setCookie(location.href)
     }
 
-    if (
-      !window.__RENDER_8_SESSION__ ||
-      !window.__RENDER_8_SESSION__.sessionPromise
-    ) {
-      return
-    }
-
-    window.__RENDER_8_SESSION__.sessionPromise.then(data => {
+    this.getSessionPromiseFromWindow().then(data => {
       const sessionResponse = (data || {}).response
       this.setState({resp: data, sessionProfile: getProfile(sessionResponse) })
     })

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -273,16 +273,6 @@ class LoginContent extends Component {
     })
   }
 
-  refetchOptions = () => {
-    const { data: query } = this.props
-    if (!query.loading && !query.loginOptions) {
-      return query.refetch()
-    }
-    if (query.loginOptions) {
-      return Promise.resolve()
-    }
-  }
-
   renderChildren = style => {
     const {
       profile,
@@ -327,7 +317,6 @@ class LoginContent extends Component {
                 }
                 isAlwaysShown={!isInitialScreenOptionOnly}
                 onOptionsClick={this.handleOptionsClick}
-                refetchOptions={this.refetchOptions}
                 loginCallback={this.onLoginSuccess}
                 providerPasswordButtonLabel={providerPasswordButtonLabel}
               />
@@ -345,6 +334,7 @@ class LoginContent extends Component {
       defaultOption,
       session,
     } = this.props
+
     const { isOnInitialScreen } = this.state
 
     // Check if the user is already logged and redirect to the return URL if it didn't receive
@@ -373,14 +363,10 @@ class LoginContent extends Component {
     )
 
     const className = classNames(
-      `${
-        styles.content
-      } flex relative bg-base justify-around overflow-visible pa4 center`,
+      `${styles.content} flex relative bg-base justify-around overflow-visible pa4 center`,
       {
         [styles.contentInitialScreen]: this.state.isOnInitialScreen,
-        [`${
-          styles.contentAlwaysWithOptions
-        } mw6-ns flex-column-reverse items-center flex-row-ns items-baseline-ns`]: !isInitialScreenOptionOnly,
+        [`${styles.contentAlwaysWithOptions} mw6-ns flex-column-reverse items-center flex-row-ns items-baseline-ns`]: !isInitialScreenOptionOnly,
         'items-baseline': isInitialScreenOptionOnly,
       }
     )

--- a/react/__tests__/Login.test.js
+++ b/react/__tests__/Login.test.js
@@ -6,72 +6,54 @@ import Login from '../Login'
 import { AuthState } from 'vtex.react-vtexid'
 
 describe('<Login /> component', () => {
-  it('should match snapshot when loading', () => {
-    AuthState.mockImplementationOnce(({ children }) => children({ loading: true }))
-
-    const { asFragment } = renderWithIntl(
-      <Login
-        isBoxOpen
-        data={{
-          loading: true,
-          refetch: () => {},
-        }}
-      />
+  it('should match snapshot when loading', async () => {
+    AuthState.mockImplementationOnce(({ children }) =>
+      children({ loading: true })
     )
 
+    const { asFragment } = renderWithIntl(<Login isBoxOpen />)
+    await Promise.resolve()
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('should match snapshot without profile', () => {
-    const { asFragment } = renderWithIntl(
-      <Login
-        isBoxOpen
-        data={{
-          loading: false,
-          refetch: () => {},
-        }}
-      />
-    )
+  it('should match snapshot without profile', async () => {
+    window.__RENDER_8_SESSION__ = {}
+    window.__RENDER_8_SESSION__.sessionPromise = Promise.resolve({
+      response: {},
+    })
+    const { asFragment } = renderWithIntl(<Login isBoxOpen />)
+    await Promise.resolve()
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('should match snapshot with profile without name', () => {
-    const { asFragment } = renderWithIntl(
-      <Login
-        isBoxOpen
-        data={{
-          loading: false,
-          refetch: () => {},
-          getSession: {
-            profile: {
-              email: 'email@vtex.com',
-              id: 'id',
-            },
+  it('should match snapshot with profile without name', async () => {
+    window.__RENDER_8_SESSION__ = {}
+    window.__RENDER_8_SESSION__.sessionPromise = Promise.resolve({
+      response: {
+        namespaces: {
+          profile: { email: { value: 'email@vtex.com' } },
+        },
+      },
+    })
+    const { asFragment } = renderWithIntl(<Login isBoxOpen />)
+    await Promise.resolve()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should match snapshot with profile with name', async () => {
+    window.__RENDER_8_SESSION__ = {}
+    window.__RENDER_8_SESSION__.sessionPromise = Promise.resolve({
+      response: {
+        namespaces: {
+          profile: {
+            email: { value: 'email@vtex.com' },
+            firstName: { value: 'firstName' },
           },
-        }}
-      />
-    )
-    expect(asFragment()).toMatchSnapshot()
-  })
-
-  it('should match snapshot with profile with name', () => {
-    const { asFragment } = renderWithIntl(
-      <Login
-        isBoxOpen
-        data={{
-          loading: false,
-          refetch: () => {},
-          getSession: {
-            profile: {
-              email: 'email@vtex.com',
-              firstName: 'firstName',
-              lastName: 'lastName',
-              id: 'id',
-            },
-          },
-        }}
-      />
-    )
+        },
+      },
+    })
+    const { asFragment } = renderWithIntl(<Login isBoxOpen />)
+    await Promise.resolve()
     expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/react/__tests__/__snapshots__/Login.test.js.snap
+++ b/react/__tests__/__snapshots__/Login.test.js.snap
@@ -93,7 +93,7 @@ exports[`<Login /> component should match snapshot with profile with name 1`] = 
               class="contentContainer shadow-3 mt3"
             >
               <div
-                class="content flex relative bg-base justify-around overflow-visible pa4 center items-baseline"
+                class="content flex relative bg-base justify-around overflow-visible pa4 center contentInitialScreen items-baseline"
               >
                 <div
                   class="contentForm dn ph4 pb6 contentFormVisible db "
@@ -185,7 +185,7 @@ exports[`<Login /> component should match snapshot with profile without name 1`]
               class="contentContainer shadow-3 mt3"
             >
               <div
-                class="content flex relative bg-base justify-around overflow-visible pa4 center items-baseline"
+                class="content flex relative bg-base justify-around overflow-visible pa4 center contentInitialScreen items-baseline"
               >
                 <div
                   class="contentForm dn ph4 pb6 contentFormVisible db "

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -8,7 +8,6 @@ import { AuthService } from 'vtex.react-vtexid'
 import { translate } from '../utils/translate'
 import styles from '../styles.css'
 
-
 // Component that shows account options to the user.
 class AccountOptions extends Component {
   static propTypes = {

--- a/react/components/EmailVerification.js
+++ b/react/components/EmailVerification.js
@@ -128,18 +128,18 @@ class EmailVerification extends Component {
                   action: sendToken,
                   validation: { validateEmail },
                 }) => (
-                    <Button
-                      variation="primary"
-                      size="small"
-                      type="submit"
-                      isLoading={loading}
-                      onClick={e =>
-                        this.handleOnSubmit(e, email, validateEmail, sendToken)
-                      }
-                    >
-                      <span className="t-small">{translate('store/login.send', intl)}</span>
-                    </Button>
-                  )}
+                  <Button
+                    variation="primary"
+                    size="small"
+                    type="submit"
+                    isLoading={loading}
+                    onClick={e =>
+                      this.handleOnSubmit(e, email, validateEmail, sendToken)
+                    }
+                  >
+                    <span className="t-small">{translate('store/login.send', intl)}</span>
+                  </Button>
+                )}
               </AuthService.SendAccessKey>
             </div>
           </Fragment>

--- a/react/components/GoBackButton.js
+++ b/react/components/GoBackButton.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 
 import { translate } from '../utils/translate'
-import LoginComponent from './LoginComponent';
+import LoginComponent from './LoginComponent'
 import styles from '../styles.css'
 
 const arrow = <IconArrowBack size={10} viewBox="0 0 16 11" />
@@ -41,7 +41,6 @@ class GoBackButton extends Component {
       </Fragment>
 
     )
-
   }
 }
 export default injectIntl(GoBackButton)

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -11,7 +11,6 @@ import LoginContent from '../LoginContent'
 import { truncateString } from '../utils/format-string'
 import { translate } from '../utils/translate'
 import { LoginPropTypes } from '../propTypes'
-import { getProfile } from '../utils/profile'
 
 import styles from '../styles.css'
 
@@ -36,34 +35,45 @@ class LoginComponent extends Component {
       intl,
       renderIconAsLink,
       onProfileIconClick,
-      data,
+      sessionProfile,
       showIconProfile,
-      runtime: { history: { location: { pathname } } },
+      runtime: {
+        history: {
+          location: { pathname },
+        },
+      },
     } = this.props
-    const profile = getProfile(data)
+
     const iconClasses = 'flex items-center'
     const iconLabel = iconLabelProfile || translate('store/login.signIn', intl)
     const iconContent = (
       <Fragment>
-        {showIconProfile && renderIconAsLink &&
-          profileIcon(iconSize, labelClasses, iconClasses)
-        }
-        {
-          profile ? (
-            <span className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}>
-              {translate('store/login.hello', intl)}{' '}
-              {profile.firstName || truncateString(profile.email)}
+        {showIconProfile &&
+          renderIconAsLink &&
+          profileIcon(iconSize, labelClasses, iconClasses)}
+        {sessionProfile ? (
+          <span
+            className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}
+          >
+            {translate('store/login.hello', intl)}{' '}
+            {sessionProfile.firstName || truncateString(sessionProfile.email)}
+          </span>
+        ) : (
+          iconLabel && (
+            <span
+              className={`${styles.label} t-action--small pl4 ${labelClasses} dn db-l`}
+            >
+              {iconLabel}
             </span>
-          ) : (
-            iconLabel && <span className={`${styles.label} t-action--small pl4 ${labelClasses} dn db-l`}>{iconLabel}</span>
           )
-        }
-      </Fragment >
+        )}
+      </Fragment>
     )
 
     if (renderIconAsLink) {
-      const linkTo = profile ? 'store.account' : 'store.login'
-      const returnUrl = !profile && `returnUrl=${encodeURIComponent(pathname)}`
+      const linkTo = sessionProfile ? 'store.account' : 'store.login'
+      const returnUrl =
+        !sessionProfile && `returnUrl=${encodeURIComponent(pathname)}`
       return (
         <Link
           page={linkTo}
@@ -76,7 +86,12 @@ class LoginComponent extends Component {
     }
 
     return (
-      <ButtonWithIcon variation="tertiary" icon={showIconProfile && profileIcon(iconSize, labelClasses)} iconPosition={showIconProfile ? "left" : "right"} onClick={onProfileIconClick}>
+      <ButtonWithIcon
+        variation="tertiary"
+        icon={showIconProfile && profileIcon(iconSize, labelClasses)}
+        iconPosition={showIconProfile ? 'left' : 'right'}
+        onClick={onProfileIconClick}
+      >
         <div
           className="flex pv2 items-center"
           ref={e => {
@@ -90,9 +105,7 @@ class LoginComponent extends Component {
   }
 
   render() {
-    const { isBoxOpen, onOutSideBoxClick, data } = this.props
-
-    const profile = getProfile(data)
+    const { isBoxOpen, onOutSideBoxClick, sessionProfile } = this.props
 
     return (
       <div className={`${styles.container} flex items-center fr`}>
@@ -101,13 +114,18 @@ class LoginComponent extends Component {
           {isBoxOpen && (
             <Overlay>
               <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
-                <div className={`${styles.box} z-max absolute`} style={{
-                  right: -50,
-                }}>
-                  <div className={`${styles.arrowUp} absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2`} />
+                <div
+                  className={`${styles.box} z-max absolute`}
+                  style={{
+                    right: -50,
+                  }}
+                >
+                  <div
+                    className={`${styles.arrowUp} absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2`}
+                  />
                   <div className={`${styles.contentContainer} shadow-3 mt3`}>
                     <LoginContent
-                      profile={profile}
+                      profile={sessionProfile}
                       loginCallback={this.onClickLoginButton}
                       isInitialScreenOptionOnly
                       {...this.props}

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -15,31 +15,22 @@ import OAuth from './OAuth'
 import styles from '../styles.css'
 
 const PROVIDERS_ICONS = {
-  'Google': GoogleIcon,
-  'Facebook': FacebookIcon,
+  Google: GoogleIcon,
+  Facebook: FacebookIcon,
 }
 
 /** LoginOptions tab component. Displays a list of login options */
 class LoginOptions extends Component {
-  state = {
-    loadingOptions: false,
-  }
-
-  handleRefetchOptions = () => {
-    if (!this.state.loadingOptions) {
-      this.setState({ loadingOptions: true })
-      this.props.refetchOptions()
-        .then(() => this.setState({ loadingOptions: false }))
-    }
-  }
-
   handleOptionClick = el => () => {
     this.props.onOptionsClick(el)
   }
 
   showOption = (option, optionName) => {
     const { isAlwaysShown, currentStep, options } = this.props
-    return options && ((options[option] && !isAlwaysShown) || currentStep !== optionName)
+    return (
+      options &&
+      ((options[option] && !isAlwaysShown) || currentStep !== optionName)
+    )
   }
 
   render() {
@@ -54,8 +45,6 @@ class LoginOptions extends Component {
       providerPasswordButtonLabel,
     } = this.props
 
-    const { loadingOptions } = this.state
-
     const classes = classNames(styles.options, className, {
       [styles.optionsSticky]: isAlwaysShown,
     })
@@ -64,64 +53,80 @@ class LoginOptions extends Component {
       <div className={classes}>
         <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
         <ul className={`${styles.optionsList} list pa0`}>
-          {options ? (
-            <Fragment>
-              {options.accessKeyAuthentication && this.showOption('accessKeyAuthentication', 'store/loginOptions.emailVerification') &&
-                <li className={`${styles.optionsListItem} mb3`}>
-                  <div className={styles.button}>
-                    <Button
-                      variation="secondary"
-                      onClick={this.handleOptionClick('store/loginOptions.emailVerification')}
-                    >
-                      <span>{translate('store/loginOptions.emailVerification', intl)}</span>
-                    </Button>
-                  </div>
-                </li>
-              }
-              {options.classicAuthentication && this.showOption('classicAuthentication', 'store/loginOptions.emailAndPassword') &&
-                <li className={`${styles.optionsListItem} mb3`}>
-                  <div className={styles.button}>
-                    <Button
-                      variation="secondary"
-                      onClick={this.handleOptionClick('store/loginOptions.emailAndPassword')}
-                    >
-                      <span>{providerPasswordButtonLabel || translate('store/loginOptions.emailAndPassword', intl)}</span>
-                    </Button>
-                  </div>
-                </li>
-              }
-              {options.providers && options.providers.map(({ providerName }, index) => {
+          <Fragment>
+            {options.accessKeyAuthentication &&
+              this.showOption(
+                'accessKeyAuthentication',
+                'store/loginOptions.emailVerification'
+              ) && (
+              <li className={`${styles.optionsListItem} mb3`}>
+                <div className={styles.button}>
+                  <Button
+                    variation="secondary"
+                    onClick={this.handleOptionClick(
+                      'store/loginOptions.emailVerification'
+                    )}
+                  >
+                    <span>
+                      {translate(
+                        'store/loginOptions.emailVerification',
+                        intl
+                      )}
+                    </span>
+                  </Button>
+                </div>
+              </li>
+            )}
+            {options.classicAuthentication &&
+              this.showOption(
+                'classicAuthentication',
+                'store/loginOptions.emailAndPassword'
+              ) && (
+              <li className={`${styles.optionsListItem} mb3`}>
+                <div className={styles.button}>
+                  <Button
+                    variation="secondary"
+                    onClick={this.handleOptionClick(
+                      'store/loginOptions.emailAndPassword'
+                    )}
+                  >
+                    <span>
+                      {providerPasswordButtonLabel ||
+                          translate(
+                            'store/loginOptions.emailAndPassword',
+                            intl
+                          )}
+                    </span>
+                  </Button>
+                </div>
+              </li>
+            )}
+            {options.providers &&
+              options.providers.map(({ providerName }, index) => {
                 const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
                 return (
                   <li
                     className={`${styles.optionsListItem} mb3`}
                     key={`${providerName}-${index}`}
                   >
-                    <OAuth provider={providerName} loginCallback={loginCallback}>
-                      {hasIcon ? React.createElement(PROVIDERS_ICONS[providerName], null) : null}
+                    <OAuth
+                      provider={providerName}
+                      loginCallback={loginCallback}
+                    >
+                      {hasIcon
+                        ? React.createElement(
+                          PROVIDERS_ICONS[providerName],
+                          null
+                        )
+                        : null}
                     </OAuth>
                   </li>
                 )
               })}
-            </Fragment>
-          ) : (
-            <li className={`${styles.optionsListItem} mb3`}>
-              <div className={`${styles.button} ${styles.buttonDanger}`}>
-                <Button
-                  type="danger"
-                  variation="secondary"
-                  isLoading={loadingOptions}
-                  onClick={this.handleRefetchOptions}
-                >
-                  <div>
-                    <div className={`${loadingOptions ? 'dn' : 'db'}`}>{translate('store/loginOptions.error.title', intl)}</div>
-                    <div className="t-small pt1">{translate('store/loginOptions.error.subhead', intl)}</div>
-                  </div>
-                </Button>
-              </div>
-            </li>
-          )}
-          <li className={`${styles.optionsListItem} ${styles.optionsListItemContainer} mb3`}>
+          </Fragment>
+          <li
+            className={`${styles.optionsListItem} ${styles.optionsListItemContainer} mb3`}
+          >
             <ExtensionContainer id="container" />
           </li>
         </ul>
@@ -145,10 +150,12 @@ LoginOptions.propTypes = {
   options: PropTypes.shape({
     accessKeyAuthentication: PropTypes.bool,
     classicAuthentication: PropTypes.bool,
-    providers: PropTypes.arrayOf(PropTypes.shape({
-      className: PropTypes.string,
-      providerName: PropTypes.string,
-    })),
+    providers: PropTypes.arrayOf(
+      PropTypes.shape({
+        className: PropTypes.string,
+        providerName: PropTypes.string,
+      })
+    ),
   }),
   /** Class of the root element */
   className: PropTypes.string,

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -140,8 +140,6 @@ LoginOptions.propTypes = {
   intl: intlShape,
   /** Function to change de active tab */
   onOptionsClick: PropTypes.func.isRequired,
-  /** Function to refetch login options */
-  refetchOptions: PropTypes.func.isRequired,
   /** Title that will be shown on top */
   title: PropTypes.string.isRequired,
   /** Fallback title that will be shown if there's no title */

--- a/react/components/RecoveryPassword.js
+++ b/react/components/RecoveryPassword.js
@@ -162,19 +162,19 @@ class RecoveryPassword extends Component {
                     validatePassword,
                   },
                 }) => (
-                    <Button
-                      variation="primary"
-                      size="small"
-                      type="submit"
-                      onClick={e => this.handleOnSubmit(e, password, token, setPassword)}
-                      isLoading={loading}
-                      disabled={!validatePassword(password)}
-                    >
-                      <span className="t-small">
-                        {translate('store/login.create', intl)}
-                      </span>
-                    </Button>
-                  )}
+                  <Button
+                    variation="primary"
+                    size="small"
+                    type="submit"
+                    onClick={e => this.handleOnSubmit(e, password, token, setPassword)}
+                    isLoading={loading}
+                    disabled={!validatePassword(password)}
+                  >
+                    <span className="t-small">
+                      {translate('store/login.create', intl)}
+                    </span>
+                  </Button>
+                )}
               </AuthService.SetPassword>
             </div>
           </Fragment>

--- a/react/package.json
+++ b/react/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "pretest": "yarn",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "lint": "eslint --ext js,jsx,ts,tsx .",
+    "lint:fix": "eslint --fix --ext js,jsx,ts,tsx ."
   },
   "dependencies": {
     "apollo-client": "^2.4.7",

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -41,7 +41,7 @@ export const LoginPropTypes = {
   data: PropTypes.shape({
     refetch: PropTypes.func.isRequired,
     profile: PropTypes.shape({}),
-  }).isRequired,
+  }),
   /** Is box with the login options should be opened or not */
   isBoxOpen: PropTypes.bool.isRequired,
   /** Should the Icon be rendered as link or not */

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -37,11 +37,8 @@ export const LoginContainerProptypes = {
 export const LoginPropTypes = {
   /** Intl object*/
   intl: intlShape,
-  /** Data object with user profile */
-  data: PropTypes.shape({
-    refetch: PropTypes.func.isRequired,
-    profile: PropTypes.shape({}),
-  }),
+  /** User profile information */
+  profile: PropTypes.shape({}),
   /** Is box with the login options should be opened or not */
   isBoxOpen: PropTypes.bool.isRequired,
   /** Should the Icon be rendered as link or not */

--- a/react/testUtils/intl-utils.js
+++ b/react/testUtils/intl-utils.js
@@ -3,7 +3,7 @@ import { render } from 'react-testing-library'
 import { IntlProvider } from 'react-intl'
 import defautMessages from '../../messages/en.json'
 
- export const renderWithIntl = (node, options) => {
+export const renderWithIntl = (node, options) => {
   const rendered = render(
     <IntlProvider messages={defautMessages} locale="en-US">
       {node}
@@ -11,7 +11,7 @@ import defautMessages from '../../messages/en.json'
     options
   )
 
-   return {
+  return {
     ...rendered,
     rerender: newUi =>
       renderWithIntl(newUi, {

--- a/react/utils/profile.js
+++ b/react/utils/profile.js
@@ -1,3 +1,48 @@
-import { path } from 'ramda'
+const getProfileFromQueryResponse = data => {
+  if (!data || !data.getProfile || !data.getProfile.profile) return null
 
-export const getProfile = data => path(['getSession', 'profile'], data)
+  const { email, firstName } = data.getProfile.profile
+  if (!email) {
+    return null
+  }
+
+  return {
+    email,
+    firstName,
+  }
+}
+
+const getProfileFromApiResponse = data => {
+  if (!data || !data.namespaces) {
+    return null
+  }
+
+  const { namespaces: { profile } = {} } = data
+  if (!profile) {
+    return null
+  }
+
+  const {
+    email: { value: email } = { value: null },
+    firstName: { value: firstName } = { value: null },
+  } = profile
+
+  if (!email) {
+    return null
+  }
+
+  return {
+    email,
+    firstName,
+  }
+}
+
+export const getProfile = data => {
+  if (!data) return null
+
+  if (data.getSession) return getProfileFromQueryResponse(data)
+
+  if (data.namespaces) return getProfileFromApiResponse(data)
+
+  return null
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
- We had components doing the getSession query and this caused a problem on the session API.

We are trying to make components use the session promise that comes from the render-session app, at least in the first render of a component.

So we now get the data from the session promise and basically do what the store-graphql resolver does to parse the profile, saving in on a state.

#### What problem is this solving?
Too many calls to the session API

#### How should this be manually tested?

Still pending a pr on `render-session`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
