### PR TITLE
Feature/mirror tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `mirrorTooltipToRight` Store Front prop to the `login` block. It makes the login open towards the right instead of the left.
+
 ## [2.18.0] - 2019-11-01
 ### Changed
 - Remove call to `getSession` in first component, use sessionPromise from render.

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 | `hasIdentifierExtension`              | `Boolean` | Enables identifier extension configurations      | -             |
 | `identifierPlaceholder`               | `String`  | Set placeholder for the identifier extension     | -             |
 | `invalidIdentifierError`              | `String`  | Set error message for invalid user identifier    | -             |
+| `mirrorTooltipToRight`                | `Boolean` | Makes login tooltip open towards the right side  | -             |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.18.0",
+  "version": "2.19.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/en.json
+++ b/messages/en.json
@@ -50,5 +50,6 @@
   "admin/editor.login.providerPasswordButtonLabel": "E-mail/Password login button label",
   "admin/editor.login.hasIdentifierExtension": "E-mail/Password user identifier extension",
   "admin/editor.login.identifierPlaceholder": "Identifier input placeholder",
-  "admin/editor.login.invalidIdentifierError": "Invalid identifier error"
+  "admin/editor.login.invalidIdentifierError": "Invalid identifier error",
+  "admin/editor.login.mirrorTooltipToRightTitle": "Makes the login tooltip open towards the right instead of the left"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -50,5 +50,6 @@
   "admin/editor.login.providerPasswordButtonLabel": "Etiqueta del botón de login con Email/Password",
   "admin/editor.login.hasIdentifierExtension": "Extensión del identificador de usuario de Email/Password",
   "admin/editor.login.identifierPlaceholder": "Placeholder del campo de identificador",
-  "admin/editor.login.invalidIdentifierError": "Error de identificador inválido"
+  "admin/editor.login.invalidIdentifierError": "Error de identificador inválido",
+  "admin/editor.login.mirrorTooltipToRightTitle": "Hace que el tooltip de inicio de sesión se abra hacia la derecha en lugar de hacia la izquierda."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -50,5 +50,6 @@
   "admin/editor.login.providerPasswordButtonLabel": "Texto do botão de login com E-mail/Senha",
   "admin/editor.login.hasIdentifierExtension": "Extensão do identificador de usuário de E-mail/Senha",
   "admin/editor.login.identifierPlaceholder": "Placeholder do campo de identificador",
-  "admin/editor.login.invalidIdentifierError": "Erro de identificador inválido"
+  "admin/editor.login.invalidIdentifierError": "Erro de identificador inválido",
+  "admin/editor.login.mirrorTooltipToRightTitle": "Faz a tooltip de login abrir para a direita ao invés da esquerda"
 }

--- a/react/Login.js
+++ b/react/Login.js
@@ -93,6 +93,14 @@ export default class Login extends Component {
 Login.getSchema = () => ({
   title: 'admin/editor.login.title',
   ...LoginSchema,
+  properties: {
+    ...LoginSchema.properties,
+    mirrorTooltipToRight: {
+      title: 'admin/editor.login.mirrorTooltipToRightTitle',
+      type: 'boolean',
+      default: 'false',
+    },
+  },
 })
 
 const LoginWithSession = withSession({

--- a/react/__tests__/__snapshots__/Login.test.js.snap
+++ b/react/__tests__/__snapshots__/Login.test.js.snap
@@ -29,7 +29,7 @@ exports[`<Login /> component should match snapshot when loading 1`] = `
             style="right: -50px;"
           >
             <div
-              class="arrowUp absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2"
+              class="arrowUp absolute top-0 right-0 mr3 shadow-3 bg-base rotate-45 h2 w2"
             />
             <div
               class="contentContainer shadow-3 mt3"
@@ -87,7 +87,7 @@ exports[`<Login /> component should match snapshot with profile with name 1`] = 
             style="right: -50px;"
           >
             <div
-              class="arrowUp absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2"
+              class="arrowUp absolute top-0 right-0 mr3 shadow-3 bg-base rotate-45 h2 w2"
             />
             <div
               class="contentContainer shadow-3 mt3"
@@ -179,7 +179,7 @@ exports[`<Login /> component should match snapshot with profile without name 1`]
             style="right: -50px;"
           >
             <div
-              class="arrowUp absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2"
+              class="arrowUp absolute top-0 right-0 mr3 shadow-3 bg-base rotate-45 h2 w2"
             />
             <div
               class="contentContainer shadow-3 mt3"
@@ -271,7 +271,7 @@ exports[`<Login /> component should match snapshot without profile 1`] = `
             style="right: -50px;"
           >
             <div
-              class="arrowUp absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2"
+              class="arrowUp absolute top-0 right-0 mr3 shadow-3 bg-base rotate-45 h2 w2"
             />
             <div
               class="contentContainer shadow-3 mt3"

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -105,7 +105,7 @@ class LoginComponent extends Component {
   }
 
   render() {
-    const { isBoxOpen, onOutSideBoxClick, sessionProfile } = this.props
+    const { isBoxOpen, onOutSideBoxClick, sessionProfile, mirrorTooltipToRight } = this.props
 
     return (
       <div className={`${styles.container} flex items-center fr`}>
@@ -114,15 +114,10 @@ class LoginComponent extends Component {
           {isBoxOpen && (
             <Overlay>
               <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
-                <div
-                  className={`${styles.box} z-max absolute`}
-                  style={{
-                    right: -50,
-                  }}
-                >
-                  <div
-                    className={`${styles.arrowUp} absolute top-0 right-0 shadow-3 bg-base mr3 rotate-45 h2 w2`}
-                  />
+                <div className={`${styles.box} z-max absolute`} style={{
+                  ...mirrorTooltipToRight ? { left: 50 } : { right: -50 },
+                }}>
+                  <div className={`${styles.arrowUp} absolute top-0 ${mirrorTooltipToRight ? 'left-0 ml3' : 'right-0 mr3'} shadow-3 bg-base rotate-45 h2 w2`} />
                   <div className={`${styles.contentContainer} shadow-3 mt3`}>
                     <LoginContent
                       profile={sessionProfile}

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -114,9 +114,7 @@ class LoginComponent extends Component {
           {isBoxOpen && (
             <Overlay>
               <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
-                <div className={`${styles.box} z-max absolute`} style={{
-                  ...mirrorTooltipToRight ? { left: 50 } : { right: -50 },
-                }}>
+                <div className={`${styles.box} z-max absolute`} style={mirrorTooltipToRight ? { left: 50 } : { right: -50 }}>
                   <div className={`${styles.arrowUp} absolute top-0 ${mirrorTooltipToRight ? 'left-0 ml3' : 'right-0 mr3'} shadow-3 bg-base rotate-45 h2 w2`} />
                   <div className={`${styles.contentContainer} shadow-3 mt3`}>
                     <LoginContent

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -32,6 +32,8 @@ export const LoginContainerProptypes = {
   identifierPlaceholder: PropTypes.string,
   /** Error message for the user identifier */
   invalidIdentifierError: PropTypes.string,
+  /** Determines if the tooltip opens to the right side */
+  mirrorTooltipToRight: PropTypes.bool,
 }
 
 export const LoginPropTypes = {

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -32,7 +32,7 @@ export const LoginContainerProptypes = {
   identifierPlaceholder: PropTypes.string,
   /** Error message for the user identifier */
   invalidIdentifierError: PropTypes.string,
-  /** Determines if the tooltip opens to the right side */
+  /** Determines if the tooltip opens towards the right side */
   mirrorTooltipToRight: PropTypes.bool,
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make it possible for the login to open towards the right instead of the left

#### What problem is this solving?
This adds the a Store Front prop to the `login` block which changes its layout.

#### How should this be manually tested?

I edited the store-theme in two workspaces to render the login in the left of the header bar. In one of them I added the prop to mirror the tooltip:
https://rafaprtest2--storecomponents.myvtex.com/

In this one, the tooltip opens in the normal direction:
https://rafaprtest3--storecomponents.myvtex.com/

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/66072301-2c3c1400-e52b-11e9-96cf-6628b6cb5847.png)

![image](https://user-images.githubusercontent.com/22064061/66072252-1dedf800-e52b-11e9-90b8-4e204cc2eb17.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Clubhouse stories:
[ch23129]