### PR TITLE
Chore/pass version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Pass app version to `react-vtexid`
+
 ## [2.16.1] - 2019-10-14
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.16.1",
+  "version": "2.16.2-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -24,6 +24,7 @@ import { LoginPropTypes } from './propTypes'
 import { getProfile } from './utils/profile'
 import { session } from 'vtex.store-resources/Queries'
 import { AuthState } from 'vtex.react-vtexid'
+import { SELF_APP_NAME_AND_VERSION } from './common/global'
 
 import styles from './styles.css'
 
@@ -379,7 +380,7 @@ class LoginContent extends Component {
       [`${styles.contentFormVisible} db `]: this.shouldRenderForm,
     })
     return (
-      <AuthState skip={!!profile} scope="STORE" returnUrl={this.returnUrl}>
+      <AuthState skip={!!profile} scope="STORE" uiNameAndVersion={SELF_APP_NAME_AND_VERSION} returnUrl={this.returnUrl}>
         {({ loading }) => (
           <div className={className}>
             {loading ? (

--- a/react/common/global.js
+++ b/react/common/global.js
@@ -1,1 +1,2 @@
 export const USER_IDENTIFIER_INTERFACE_ID = 'user-identifier'
+export const SELF_APP_NAME_AND_VERSION = process.env.VTEX_APP_ID || process.env.VTEX_APP_NAME || null


### PR DESCRIPTION
#### What is the purpose of this pull request?

Pass the app version to `react-vtexid` for it to be logged

#### How should this be manually tested?

Go to
https://rafaprtest5--parceiro01.myvtex.com/
And try to log in to the store. You should see in the `network` requests that requests to `/api/vtexid` contain the `vtexid-ui-version` header containing the string `vtex.login@2.16.0`

![image](https://user-images.githubusercontent.com/22064061/66593172-db509f00-eb6c-11e9-9992-260c06493f37.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
