### PR TITLE
Fix/wrong credentials feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add error feedback for when the user types a wrong code in "Forgot Password" screen
+
 ## [2.19.0] - 2019-11-11
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.19.0",
+  "version": "2.19.1-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/context.json
+++ b/messages/context.json
@@ -19,6 +19,7 @@
   "store/login.invalidPassword": "store/login.invalidPassword",
   "store/login.invalidCode": "store/login.invalidCode",
   "store/login.invalidMatch": "store/login.invalidMatch",
+  "store/login.wrongCode": "store/login.wrongCode",
   "store/login.wrongCredentials": "store/login.wrongCredentials",
   "store/login.userBlocked": "store/login.userBlocked",
   "store/login.createPassword": "store/login.createPassword",

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,6 +19,7 @@
   "store/login.invalidPassword": "Your password must contains: at least 8 characters, including numbers, lowercase and uppercase letters",
   "store/login.invalidMatch": "Password confirmation is incorrect",
   "store/login.invalidCode": "Insert a valid 6-digit access code",
+  "store/login.wrongCode": "The access code is incorrect",
   "store/login.wrongCredentials": "Wrong user and/or password",
   "store/login.userBlocked": "You have entered an incorrect password 4 times. Your user has been blocked for an hour",
   "store/login.createPassword": "Create a new password",

--- a/messages/es.json
+++ b/messages/es.json
@@ -19,6 +19,7 @@
   "store/login.invalidPassword": "Su contraseña debe contener: 8 caracteres, números y letras minúsculas y mayúsculas",
   "store/login.invalidMatch": "Confirmación de contraseña está incorrecta",
   "store/login.invalidCode": "Ingrese un código de acceso válido de 6 dígitos",
+  "store/login.wrongCode": "El código de acceso es incorrecto",
   "store/login.wrongCredentials": "Usuario y/o contraseña equivocada",
   "store/login.userBlocked": "Usted se equivocó 4 veces al ingresar su contraseña. Su usuario fue bloqueado por una hora",
   "store/login.createPassword": "Crear una nueva contraseña",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -19,6 +19,7 @@
   "store/login.invalidPassword": "Sua senha deve conter: no mínimo 8 caracteres, incluindo números, letras minúsculas e maiúsculas",
   "store/login.invalidMatch": "Confirmação de senha está incorreta",
   "store/login.invalidCode": "Insira um código de acesso válido de 6 dígitos",
+  "store/login.wrongCode": "O código de acesso está incorreto",
   "store/login.wrongCredentials": "Usuário e/ou senha errada",
   "store/login.userBlocked": "Você digitou uma senha incorreta 4 vezes. Seu usuário foi bloqueado por uma hora",
   "store/login.createPassword": "Criar uma nova senha",

--- a/react/components/RecoveryPassword.js
+++ b/react/components/RecoveryPassword.js
@@ -24,6 +24,7 @@ class RecoveryPassword extends Component {
       isInvalidPassword: false,
       isPasswordsMatch: true,
       isInvalidCode: false,
+      isWrongCode: false,
       isUserBlocked: false,
       confirmPassword: '',
     }
@@ -43,9 +44,13 @@ class RecoveryPassword extends Component {
   }
 
   handleFailure = err => {
-    err.code === 'BlockedUser'
-      ? this.setState({ isUserBlocked: true })
-      : console.error(err)
+    if (err.code === 'BlockedUser') {
+      this.setState({ isUserBlocked: true })
+    } else if (err.code === 'WrongCredentials') {
+      this.setState({ isWrongCode: true })
+    } else {
+      console.error(err)
+    }
   }
 
   handleOnSubmit = (event, newPassword, token, setPassword) => {
@@ -76,6 +81,7 @@ class RecoveryPassword extends Component {
       isInvalidPassword,
       isUserBlocked,
       isInvalidCode,
+      isWrongCode,
       isPasswordsMatch,
     } = this.state
 
@@ -94,7 +100,7 @@ class RecoveryPassword extends Component {
                     name="token"
                     onChange={e => {
                       setValue(e.target.value)
-                      this.setState({ isInvalidCode: false })
+                      this.setState({ isInvalidCode: false, isWrongCode: false })
                     }}
                     value={value || ''}
                     placeholder={
@@ -107,6 +113,9 @@ class RecoveryPassword extends Component {
             </div>
             <FormError show={isInvalidCode}>
               {translate('store/login.invalidCode', intl)}
+            </FormError>
+            <FormError show={isWrongCode}>
+              {translate('store/login.wrongCode', intl)}
             </FormError>
             <div className={`${styles.inputContainer} ${styles.inputContainerPassword} pv3`}>
               <AuthState.Password>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the lack of feedback in the "Forgot Password" screen when the wrong access code was input

#### What problem is this solving?
This adds error feedback for when the wrong access code is submitted

#### How should this be manually tested?

http://rafaprtest--storecomponents.myvtex.com/
Click "Sign in" > "Sign in with email and password" > "Forgot my password"
Then type any email and click send. Type any wrong access code, such as `123456` and two valid passwords. Then click "Create" and you will see the error displayed below

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/68047833-033fa800-fcbe-11e9-9fd1-d42960f54b41.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
