### PR TITLE
added showIconProfile prop to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `showIconProfile` prop on README.md
+
 ## [2.19.1] - 2019-11-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `showIconProfile` prop on README.md
+- `showIconProfile` and `iconLabel` props to documentation
 
 ## [2.19.1] - 2019-11-12
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 | `showPasswordVerificationIntoTooltip` | `Boolean` | Set show password format verification as tooltip | -             |
 | `acessCodePlaceholder`                | `String`  | Set placeholder to access code input             | -             |
 | `showIconProfile`                     | `Boolean` | Enables icon `hpa-profile`                       | -             |
+| `iconLabel`                           | `String`  | Set label of the login button                    | -             |
 | `providerPasswordButtonLabel`         | `String`  | Set Password login button text                   | -             |
 | `hasIdentifierExtension`              | `Boolean` | Enables identifier extension configurations      | -             |
 | `identifierPlaceholder`               | `String`  | Set placeholder for the identifier extension     | -             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,6 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 
 | Prop name                             | Type      | Description                                      | Default value |
 | ------------------------------------- | --------- | ------------------------------------------------ | ------------- |
-| `showIconProfile`                     | `Boolean` | Enables icon `hpa-profile`                       | false         |
 | `optionsTitle`                        | `String`  | Set title of login options                       | -             |
 | `emailAndPasswordTitle`               | `String`  | Set title of login with email and password       | -             |
 | `accessCodeTitle`                     | `String`  | Set title of login by access code                | -             |
@@ -102,6 +101,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 | `passwordPlaceholder`                 | `String`  | Set placeholder to password input                | -             |
 | `showPasswordVerificationIntoTooltip` | `Boolean` | Set show password format verification as tooltip | -             |
 | `acessCodePlaceholder`                | `String`  | Set placeholder to access code input             | -             |
+| `showIconProfile`                     | `Boolean` | Enables icon `hpa-profile`                       | -             |
 | `providerPasswordButtonLabel`         | `String`  | Set Password login button text                   | -             |
 | `hasIdentifierExtension`              | `Boolean` | Enables identifier extension configurations      | -             |
 | `identifierPlaceholder`               | `String`  | Set placeholder for the identifier extension     | -             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 
 | Prop name                             | Type      | Description                                      | Default value |
 | ------------------------------------- | --------- | ------------------------------------------------ | ------------- |
+| `showIconProfile`                     | `Boolean` | Enables icon `hpa-profile`                       | false         |
 | `optionsTitle`                        | `String`  | Set title of login options                       | -             |
 | `emailAndPasswordTitle`               | `String`  | Set title of login with email and password       | -             |
 | `accessCodeTitle`                     | `String`  | Set title of login by access code                | -             |


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add documentation to showIconProfile docs.

#### What problem is this solving?
Nobody knew that it was possible to "enable" the profile icon on login.



#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
