### PR TITLE
Add new iconsProps prop to LoginComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `iconsProps` prop to `LoginComponent`.
+
 ## [2.19.2] - 2019-11-13
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,23 +92,25 @@ For now these blocks do not have any required or optional blocks.
 
 Through the Storefront, you can change the `login`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name                             | Type                                    | Description                                              | Default value |
-| ------------------------------------- | --------------------------------------- | -------------------------------------------------------- | ------------- |
-| `optionsTitle`                        | `String`                                | Set title of login options                               | -             |
-| `emailAndPasswordTitle`               | `String`                                | Set title of login with email and password               | -             |
-| `accessCodeTitle`                     | `String`                                | Set title of login by access code                        | -             |
-| `emailPlaceholder`                    | `String`                                | Set placeholder to email input                           | -             |
-| `passwordPlaceholder`                 | `String`                                | Set placeholder to password input                        | -             |
-| `showPasswordVerificationIntoTooltip` | `Boolean`                               | Set show password format verification as tooltip         | -             |
-| `acessCodePlaceholder`                | `String`                                | Set placeholder to access code input                     | -             |
-| `showIconProfile`                     | `Boolean`                               | Enables icon `hpa-profile`                               | -             |
-| `iconLabel`                           | `String`                                | Set label of the login button                            | -             |
-| `providerPasswordButtonLabel`         | `String`                                | Set Password login button text                           | -             |
-| `hasIdentifierExtension`              | `Boolean`                               | Enables identifier extension configurations              | -             |
-| `identifierPlaceholder`               | `String`                                | Set placeholder for the identifier extension             | -             |
-| `invalidIdentifierError`              | `String`                                | Set error message for invalid user identifier            | -             |
-| `mirrorTooltipToRight`                | `Boolean`                               | Makes login tooltip open towards the right side          | -             |
-| `iconsProps`                          | `{ "viewBox": String, "size": Number }` | Props to be passed down to the icons from `store-icons`. | -             |
+| Prop name                                         | Type                                    | Description                                              | Default value |
+| ------------------------------------------------- | --------------------------------------- | -------------------------------------------------------- | ------------- |
+| `optionsTitle`                                    | `String`                                | Set title of login options                               | -             |
+| `emailAndPasswordTitle`                           | `String`                                | Set title of login with email and password               | -             |
+| `accessCodeTitle`                                 | `String`                                | Set title of login by access code                        | -             |
+| `emailPlaceholder`                                | `String`                                | Set placeholder to email input                           | -             |
+| `passwordPlaceholder`                             | `String`                                | Set placeholder to password input                        | -             |
+| `showPasswordVerificationIntoTooltip`             | `Boolean`                               | Set show password format verification as tooltip         | -             |
+| `acessCodePlaceholder`                            | `String`                                | Set placeholder to access code input                     | -             |
+| `showIconProfile`                                 | `Boolean`                               | Enables icon `hpa-profile`                               | -             |
+| `iconSize` (DEPRECATED - use iconsProps instead)  | `Number`                                | Set size of the profile icon                             | -             |
+| `iconLabel`                                       | `String`                                | Set label of the login button                            | -             |
+| `labelClasses`                                    | `String`                                | Label's classnames                                       | -             |
+| `providerPasswordButtonLabel`                     | `String`                                | Set Password login button text                           | -             |
+| `hasIdentifierExtension`                          | `Boolean`                               | Enables identifier extension configurations              | -             |
+| `identifierPlaceholder`                           | `String`                                | Set placeholder for the identifier extension             | -             |
+| `invalidIdentifierError`                          | `String`                                | Set error message for invalid user identifier            | -             |
+| `mirrorTooltipToRight`                            | `Boolean`                               | Makes login tooltip open towards the right side          | -             |
+| `iconsProps`                                      | `{ "viewBox": String, "size": Number }` | Props to be passed down to the icons from `store-icons`. | -             |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,22 +92,23 @@ For now these blocks do not have any required or optional blocks.
 
 Through the Storefront, you can change the `login`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name                             | Type      | Description                                      | Default value |
-| ------------------------------------- | --------- | ------------------------------------------------ | ------------- |
-| `optionsTitle`                        | `String`  | Set title of login options                       | -             |
-| `emailAndPasswordTitle`               | `String`  | Set title of login with email and password       | -             |
-| `accessCodeTitle`                     | `String`  | Set title of login by access code                | -             |
-| `emailPlaceholder`                    | `String`  | Set placeholder to email input                   | -             |
-| `passwordPlaceholder`                 | `String`  | Set placeholder to password input                | -             |
-| `showPasswordVerificationIntoTooltip` | `Boolean` | Set show password format verification as tooltip | -             |
-| `acessCodePlaceholder`                | `String`  | Set placeholder to access code input             | -             |
-| `showIconProfile`                     | `Boolean` | Enables icon `hpa-profile`                       | -             |
-| `iconLabel`                           | `String`  | Set label of the login button                    | -             |
-| `providerPasswordButtonLabel`         | `String`  | Set Password login button text                   | -             |
-| `hasIdentifierExtension`              | `Boolean` | Enables identifier extension configurations      | -             |
-| `identifierPlaceholder`               | `String`  | Set placeholder for the identifier extension     | -             |
-| `invalidIdentifierError`              | `String`  | Set error message for invalid user identifier    | -             |
-| `mirrorTooltipToRight`                | `Boolean` | Makes login tooltip open towards the right side  | -             |
+| Prop name                             | Type                                    | Description                                              | Default value |
+| ------------------------------------- | --------------------------------------- | -------------------------------------------------------- | ------------- |
+| `optionsTitle`                        | `String`                                | Set title of login options                               | -             |
+| `emailAndPasswordTitle`               | `String`                                | Set title of login with email and password               | -             |
+| `accessCodeTitle`                     | `String`                                | Set title of login by access code                        | -             |
+| `emailPlaceholder`                    | `String`                                | Set placeholder to email input                           | -             |
+| `passwordPlaceholder`                 | `String`                                | Set placeholder to password input                        | -             |
+| `showPasswordVerificationIntoTooltip` | `Boolean`                               | Set show password format verification as tooltip         | -             |
+| `acessCodePlaceholder`                | `String`                                | Set placeholder to access code input                     | -             |
+| `showIconProfile`                     | `Boolean`                               | Enables icon `hpa-profile`                               | -             |
+| `iconLabel`                           | `String`                                | Set label of the login button                            | -             |
+| `providerPasswordButtonLabel`         | `String`                                | Set Password login button text                           | -             |
+| `hasIdentifierExtension`              | `Boolean`                               | Enables identifier extension configurations              | -             |
+| `identifierPlaceholder`               | `String`                                | Set placeholder for the identifier extension             | -             |
+| `invalidIdentifierError`              | `String`                                | Set error message for invalid user identifier            | -             |
+| `mirrorTooltipToRight`                | `Boolean`                               | Makes login tooltip open towards the right side          | -             |
+| `iconsProps`                          | `{ "viewBox": String, "size": Number }` | Props to be passed down to the icons from `store-icons`. | -             |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 
@@ -134,15 +135,17 @@ This app can be extended through the `plugins.json` file of the store builder. T
 #### User Identifier Extension
 
 The Email/Password login takes two inputs:
+
 - The user email (his identifier)
 - The user password
 
-The `User Identifier Extension` allows other identifiers to be used in the login form, *as long as it can be resolved to the user email*.
+The `User Identifier Extension` allows other identifiers to be used in the login form, _as long as it can be resolved to the user email_.
 For example, if your account stores the National Identity Document of each user, the Email/Password login would be changed to ask for the following two inputs:
+
 - The user National Identity Document (his identifier)
 - The user password
 
-There is a limitation to this feature. Every user must have an email to be logged in, so the user identifier *must be able to be resolved to an email*. If you want to use an identifier other than the email, you must create a resolver app (or an extension app) that returns an email, given an identifier.
+There is a limitation to this feature. Every user must have an email to be logged in, so the user identifier _must be able to be resolved to an email_. If you want to use an identifier other than the email, you must create a resolver app (or an extension app) that returns an email, given an identifier.
 For example, imagine the user `John`, whose email is `john@example.com` and whose National Identity Document is `12345`. When he types his document (`12345`), your app must receive the `12345`, find out that it belongs to John, find out that John's email is `john@example.com` and return this email to the login app.
 
 When an extension app returns an email to the login app, it acts like the user just typed in that email. So if it returns `null`, for example, a message like `"The email is invalid"` will appear. This message, along with some others, may be edited in the Store Front, as described in the `Blocks API` section (eg. `"The User Identifier Extension is invalid"`).
@@ -152,6 +155,7 @@ When an extension app returns an email to the login app, it acts like the user j
 To create your extension app, there are five steps you must worry about.
 
 - First, you must add `login` as your app's dependency. In the `manifest.json` file:
+
 ```json
 "dependencies": {
   "vtex.login": "2.x"
@@ -159,6 +163,7 @@ To create your extension app, there are five steps you must worry about.
 ```
 
 - Second, you need to add the `store` builder to your app. In the `manifest.json` file:
+
 ```json
 "builders": {
   "store": "0.x",
@@ -166,6 +171,7 @@ To create your extension app, there are five steps you must worry about.
 ```
 
 - Third, you must extend the `user-identifier` `interface` defined by the login app. You can choose any interface name you want, which will be represented here by {{InterfaceName}}. You will need to create a component for that interface, but for now it will be represented by {{ComponentName}}. In the `store/interfaces.json` file:
+
 ```json
 "user-identifier.{{InterfaceName}}": {
   "component": "{{ComponentName}}"
@@ -173,6 +179,7 @@ To create your extension app, there are five steps you must worry about.
 ```
 
 - Fourth, you must plug in your `interface` to the login app. In the `store/plugins.json` file:
+
 ```json
 "login > user-identifier": "user-identifier.{{InterfaceName}}",
 "login-content > user-identifier": "user-identifier.{{InterfaceName}}",
@@ -183,7 +190,11 @@ To create your extension app, there are five steps you must worry about.
 ```js
 import { useState, useCallback, useEffect } from 'react'
 
-const ComponentName = ({ renderInput, identifierPlaceholder, registerSubmitter }) => {
+const ComponentName = ({
+  renderInput,
+  identifierPlaceholder,
+  registerSubmitter,
+}) => {
   // The component receives 3 props:
   // - renderInput is a function that returns the same Input component used by the login app, defined in styleguide.
   //   It receives an object with three named parameters, trivially used by Inputs with react: value, onChange, placeholder.
@@ -220,7 +231,6 @@ const ComponentName = ({ renderInput, identifierPlaceholder, registerSubmitter }
 }
 
 export default ComponentName
-
 ```
 
 After following the five steps, your extension app will be good to go. Just install it in your account and it will replace the `email` Input in the login form.
@@ -295,7 +305,7 @@ You can check if others are passing through similar issues [here](https://github
 
 ## Contributing
 
-Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project. 
+Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project.
 
 ## Tests
 

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -14,9 +14,9 @@ import { LoginPropTypes } from '../propTypes'
 
 import styles from '../styles.css'
 
-const profileIcon = (iconSize, labelClasses, classes) => (
+const profileIcon = (iconSize, labelClasses, classes, iconsProps) => (
   <div className={classNames(labelClasses, classes)}>
-    <IconProfile size={iconSize} />
+    <IconProfile size={iconSize} {...iconsProps} />
   </div>
 )
 class LoginComponent extends Component {
@@ -37,6 +37,7 @@ class LoginComponent extends Component {
       onProfileIconClick,
       sessionProfile,
       showIconProfile,
+      iconsProps,
       runtime: {
         history: {
           location: { pathname },
@@ -50,7 +51,7 @@ class LoginComponent extends Component {
       <Fragment>
         {showIconProfile &&
           renderIconAsLink &&
-          profileIcon(iconSize, labelClasses, iconClasses)}
+          profileIcon(iconSize, labelClasses, iconClasses, iconsProps)}
         {sessionProfile ? (
           <span
             className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}
@@ -88,7 +89,9 @@ class LoginComponent extends Component {
     return (
       <ButtonWithIcon
         variation="tertiary"
-        icon={showIconProfile && profileIcon(iconSize, labelClasses)}
+        icon={
+          showIconProfile && profileIcon(iconSize, labelClasses, '', iconsProps)
+        }
         iconPosition={showIconProfile ? 'left' : 'right'}
         onClick={onProfileIconClick}
       >
@@ -105,7 +108,12 @@ class LoginComponent extends Component {
   }
 
   render() {
-    const { isBoxOpen, onOutSideBoxClick, sessionProfile, mirrorTooltipToRight } = this.props
+    const {
+      isBoxOpen,
+      onOutSideBoxClick,
+      sessionProfile,
+      mirrorTooltipToRight,
+    } = this.props
 
     return (
       <div className={`${styles.container} flex items-center fr`}>
@@ -114,8 +122,15 @@ class LoginComponent extends Component {
           {isBoxOpen && (
             <Overlay>
               <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
-                <div className={`${styles.box} z-max absolute`} style={mirrorTooltipToRight ? { left: 50 } : { right: -50 }}>
-                  <div className={`${styles.arrowUp} absolute top-0 ${mirrorTooltipToRight ? 'left-0 ml3' : 'right-0 mr3'} shadow-3 bg-base rotate-45 h2 w2`} />
+                <div
+                  className={`${styles.box} z-max absolute`}
+                  style={mirrorTooltipToRight ? { left: 50 } : { right: -50 }}
+                >
+                  <div
+                    className={`${styles.arrowUp} absolute top-0 ${
+                      mirrorTooltipToRight ? 'left-0 ml3' : 'right-0 mr3'
+                    } shadow-3 bg-base rotate-45 h2 w2`}
+                  />
                   <div className={`${styles.contentContainer} shadow-3 mt3`}>
                     <LoginContent
                       profile={sessionProfile}

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -49,6 +49,11 @@ export const LoginPropTypes = {
   onOutSideBoxClick: PropTypes.func.isRequired,
   /** Function called when the user clicks on the icon*/
   onProfileIconClick: PropTypes.func.isRequired,
+  /** Props to passed to icons from store-icons */
+  iconsProps: PropTypes.shape({
+    viewBox: PropTypes.string,
+    size: PropTypes.number,
+  }),
   /** Runtime context. */
   runtime: PropTypes.shape({
     history: PropTypes.shape({

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -34,6 +34,11 @@ export const LoginContainerProptypes = {
   invalidIdentifierError: PropTypes.string,
   /** Determines if the tooltip opens towards the right side */
   mirrorTooltipToRight: PropTypes.bool,
+  /** Props passed to icons from store-icons */
+  iconsProps: PropTypes.shape({
+    viewBox: PropTypes.string,
+    size: PropTypes.number,
+  }),
 }
 
 export const LoginPropTypes = {
@@ -49,11 +54,6 @@ export const LoginPropTypes = {
   onOutSideBoxClick: PropTypes.func.isRequired,
   /** Function called when the user clicks on the icon*/
   onProfileIconClick: PropTypes.func.isRequired,
-  /** Props passed to icons from store-icons */
-  iconsProps: PropTypes.shape({
-    viewBox: PropTypes.string,
-    size: PropTypes.number,
-  }),
   /** Runtime context. */
   runtime: PropTypes.shape({
     history: PropTypes.shape({

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -49,7 +49,7 @@ export const LoginPropTypes = {
   onOutSideBoxClick: PropTypes.func.isRequired,
   /** Function called when the user clicks on the icon*/
   onProfileIconClick: PropTypes.func.isRequired,
-  /** Props to passed to icons from store-icons */
+  /** Props passed to icons from store-icons */
   iconsProps: PropTypes.shape({
     viewBox: PropTypes.string,
     size: PropTypes.number,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add new `iconsProps` prop to LoginComponent.

This should enable the user to have greater control over the profile icon from `store-icons` being used by the login app.

#### How should this be manually tested?

See how weird the icons from Login look:
[Workspace](https://storeicons--storecomponents.myvtex.com/)

This was achieved with:

```json
"login": {
    "props": {
      "showIconProfile": true,
      "iconsProps": {
        "viewBox": "0, 0, 32, 32",
        "size": 90
      }
    }
  },
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
