### PR TITLE
Change away from deprecated prop

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.19.2",
+  "version": "2.19.3-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -375,7 +375,7 @@ class LoginContent extends Component {
       [`${styles.contentFormVisible} db `]: this.shouldRenderForm,
     })
     return (
-      <AuthState skip={!!profile} scope="STORE" uiNameAndVersion={SELF_APP_NAME_AND_VERSION} returnUrl={this.returnUrl}>
+      <AuthState skip={!!profile} scope="STORE" parentAppId={SELF_APP_NAME_AND_VERSION} returnUrl={this.returnUrl}>
         {({ loading }) => (
           <div className={className}>
             {loading ? (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change prop name because it was deprecated by `react-vtexid`

#### How should this be manually tested?

Go to
https://rafaprtest--storecomponents.myvtex.com/ 
Then open the devtools > network and try to log in. You will see that requests to `/api/vtexid` still carry the `vtexid-ui-version` header containing `vtex.login*`

![image](https://user-images.githubusercontent.com/22064061/68870963-7bed2e00-06da-11ea-97f4-ff976f6778fb.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
