### PR TITLE
Use icons from store-icons as blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `icon-profile`, `icon-arrow-back` and `icon-eye-sight` blocks to be used by `login` and `login-content`. This enables the user to customize the props passed to each of those icons.
+
 ## [2.19.3] - 2019-11-21
 
 ## [2.19.2] - 2019-11-13

--- a/react/components/GoBackButton.js
+++ b/react/components/GoBackButton.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import { ButtonWithIcon } from 'vtex.styleguide'
-import { IconArrowBack } from 'vtex.store-icons'
+import { ExtensionPoint } from 'vtex.render-runtime'
 
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
@@ -9,7 +9,9 @@ import { translate } from '../utils/translate'
 import LoginComponent from './LoginComponent'
 import styles from '../styles.css'
 
-const arrow = <IconArrowBack size={10} viewBox="0 0 16 11" />
+const arrow = (
+  <ExtensionPoint id="icon-arrow-back" size={10} viewBox="0 0 16 11" />
+)
 
 class GoBackButton extends Component {
   static propTypes = {
@@ -39,7 +41,6 @@ class GoBackButton extends Component {
           </ButtonWithIcon>
         </div>
       </Fragment>
-
     )
   }
 }

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -4,7 +4,7 @@ import OutsideClickHandler from 'react-outside-click-handler'
 import classNames from 'classnames'
 
 import { ButtonWithIcon } from 'vtex.styleguide'
-import { IconProfile } from 'vtex.store-icons'
+import { ExtensionPoint } from 'vtex.render-runtime'
 import Overlay from 'vtex.react-portal/Overlay'
 
 import LoginContent from '../LoginContent'
@@ -16,7 +16,7 @@ import styles from '../styles.css'
 
 const profileIcon = (iconSize, labelClasses, classes) => (
   <div className={classNames(labelClasses, classes)}>
-    <IconProfile size={iconSize} />
+    <ExtensionPoint id="icon-profile" size={iconSize} />
   </div>
 )
 class LoginComponent extends Component {
@@ -105,7 +105,12 @@ class LoginComponent extends Component {
   }
 
   render() {
-    const { isBoxOpen, onOutSideBoxClick, sessionProfile, mirrorTooltipToRight } = this.props
+    const {
+      isBoxOpen,
+      onOutSideBoxClick,
+      sessionProfile,
+      mirrorTooltipToRight,
+    } = this.props
 
     return (
       <div className={`${styles.container} flex items-center fr`}>
@@ -114,8 +119,15 @@ class LoginComponent extends Component {
           {isBoxOpen && (
             <Overlay>
               <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
-                <div className={`${styles.box} z-max absolute`} style={mirrorTooltipToRight ? { left: 50 } : { right: -50 }}>
-                  <div className={`${styles.arrowUp} absolute top-0 ${mirrorTooltipToRight ? 'left-0 ml3' : 'right-0 mr3'} shadow-3 bg-base rotate-45 h2 w2`} />
+                <div
+                  className={`${styles.box} z-max absolute`}
+                  style={mirrorTooltipToRight ? { left: 50 } : { right: -50 }}
+                >
+                  <div
+                    className={`${styles.arrowUp} absolute top-0 ${
+                      mirrorTooltipToRight ? 'left-0 ml3' : 'right-0 mr3'
+                    } shadow-3 bg-base rotate-45 h2 w2`}
+                  />
                   <div className={`${styles.contentContainer} shadow-3 mt3`}>
                     <LoginContent
                       profile={sessionProfile}

--- a/react/components/PasswordInput.js
+++ b/react/components/PasswordInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 
 import { Input } from 'vtex.styleguide'
-import { IconEyeSight } from 'vtex.store-icons'
+import { ExtensionPoint } from 'vtex.render-runtime'
 
 import { translate } from '../utils/translate'
 import PasswordValidationContent from './PasswordValidationContent'
@@ -97,11 +97,16 @@ class PasswordInput extends Component {
             this.props.placeholder ||
             translate('store/login.password.placeholder', intl)
           }
-          onBlur={() => this.setState({ showVerification: !showPasswordVerificationIntoTooltip })}
+          onBlur={() =>
+            this.setState({
+              showVerification: !showPasswordVerificationIntoTooltip,
+            })
+          }
           onFocus={() => this.setState({ showVerification: true })}
           suffixIcon={
             <span className="pointer" onClick={this.handleEyeIcon}>
-              <IconEyeSight
+              <ExtensionPoint
+                id="icon-eye-sight"
                 type="filled"
                 state={showPassword ? 'off' : 'on'}
                 size={16}

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,0 +1,8 @@
+{
+  "login": {
+    "blocks": ["icon-profile", "icon-eye-sight", "icon-arrow-back"]
+  },
+  "login-content": {
+    "blocks": ["icon-profile", "icon-eye-sight", "icon-arrow-back"]
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,12 +2,22 @@
   "login": {
     "component": "Login",
     "render": "client",
-    "allowed": ["user-identifier"]
+    "allowed": [
+      "user-identifier",
+      "icon-profile",
+      "icon-eye-sight",
+      "icon-arrow-back"
+    ]
   },
   "login-content": {
     "component": "LoginContent",
     "render": "client",
-    "allowed": ["user-identifier"]
+    "allowed": [
+      "user-identifier",
+      "icon-profile",
+      "icon-eye-sight",
+      "icon-arrow-back"
+    ]
   },
   "user-identifier": {
     "component": "*",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Allow icons from `vtex.store-icons` to be passed as blocks to `login` and `login-content` blocks. That way users can customize each individual icon.

#### What problem is this solving?

This should enable users to customize the props being passed to each icon.

#### How should this be manually tested?

This is linked here: [Workspace](https://storeicons--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Notes

This depends on: https://github.com/vtex-apps/store-icons/pull/37
