### PR TITLE
Add missing documentation on new icon blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Information on new icon blocks to the documentation.
+
 ## [2.20.1] - 2019-12-02
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,8 @@ Now, you can change the behavior of the `login` block that is in the store heade
 }
 ```
 
+This app also uses SVG icons from [`store-icons`](https://github.com/vtex-apps/store-icons), which means any icons used by it can be customized. Use `icon-profile`, `icon-eye-sight` and `icon-arrow-back` blocks to configure these icons via props, if you wish to change their default `size`(`height` and `width`) or `viewBox`.
+
 ### Blocks API
 
 When implementing this app as a block, various inner blocks may be available. The following interface lists the available blocks within `login` and `login-content` and describes if they are required or optional.


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add missing documentation on new icon blocks and how they should could be used.

#### What problem is this solving?

Outdated documentation.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
