### PR TITLE
Fix scenarios where icons would not render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Scenarios where the icons would not be rendered if the user did not provide the icon blocks.
+
 ## [2.20.0] - 2019-11-25
 
 ### Added

--- a/react/components/GoBackButton.js
+++ b/react/components/GoBackButton.js
@@ -1,17 +1,23 @@
 import React, { Component, Fragment } from 'react'
 import { ButtonWithIcon } from 'vtex.styleguide'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
+import { IconArrowBack } from 'vtex.store-icons'
 
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 
 import { translate } from '../utils/translate'
-import LoginComponent from './LoginComponent'
 import styles from '../styles.css'
 
-const arrow = (
-  <ExtensionPoint id="icon-arrow-back" size={10} viewBox="0 0 16 11" />
-)
+const Arrow = () => {
+  const hasIconBlock = Boolean(useChildBlock({ id: 'icon-arrow-back' }))
+
+  return hasIconBlock ? (
+    <ExtensionPoint id="icon-arrow-back" size={10} viewBox="0 0 16 11" />
+  ) : (
+    <IconArrowBack size={10} viewBox="0 0 16 11" />
+  )
+}
 
 class GoBackButton extends Component {
   static propTypes = {
@@ -29,7 +35,7 @@ class GoBackButton extends Component {
       <Fragment>
         <div className={styles.backButton}>
           <ButtonWithIcon
-            icon={arrow}
+            icon={<Arrow />}
             iconPosition="left"
             variation="tertiary"
             size="small"

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -1,11 +1,16 @@
 import React, { Component, Fragment } from 'react'
-import { Link, withRuntimeContext } from 'vtex.render-runtime'
+import {
+  Link,
+  withRuntimeContext,
+  ExtensionPoint,
+  useChildBlock,
+} from 'vtex.render-runtime'
 import OutsideClickHandler from 'react-outside-click-handler'
 import classNames from 'classnames'
 
-import { ButtonWithIcon } from 'vtex.styleguide'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { IconProfile } from 'vtex.store-icons'
 import Overlay from 'vtex.react-portal/Overlay'
+import { ButtonWithIcon } from 'vtex.styleguide'
 
 import LoginContent from '../LoginContent'
 import { truncateString } from '../utils/format-string'
@@ -14,11 +19,24 @@ import { LoginPropTypes } from '../propTypes'
 
 import styles from '../styles.css'
 
-const profileIcon = (iconSize, labelClasses, classes) => (
-  <div className={classNames(labelClasses, classes)}>
-    <ExtensionPoint id="icon-profile" size={iconSize} />
-  </div>
-)
+const ProfileIcon = ({ iconSize, labelClasses, classes }) => {
+  const hasIconBlock = Boolean(useChildBlock({ id: 'icon-profile' }))
+
+  if (hasIconBlock) {
+    return (
+      <div className={classNames(labelClasses, classes)}>
+        <ExtensionPoint id="icon-profile" size={iconSize} />
+      </div>
+    )
+  }
+
+  return (
+    <div className={classNames(labelClasses, classes)}>
+      <IconProfile size={iconSize} />
+    </div>
+  )
+}
+
 class LoginComponent extends Component {
   static propTypes = LoginPropTypes
 
@@ -48,9 +66,13 @@ class LoginComponent extends Component {
     const iconLabel = iconLabelProfile || translate('store/login.signIn', intl)
     const iconContent = (
       <Fragment>
-        {showIconProfile &&
-          renderIconAsLink &&
-          profileIcon(iconSize, labelClasses, iconClasses)}
+        {showIconProfile && renderIconAsLink && (
+          <ProfileIcon
+            iconSize={iconSize}
+            labelClasses={labelClasses}
+            iconClasses={iconClasses}
+          />
+        )}
         {sessionProfile ? (
           <span
             className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}
@@ -88,7 +110,11 @@ class LoginComponent extends Component {
     return (
       <ButtonWithIcon
         variation="tertiary"
-        icon={showIconProfile && profileIcon(iconSize, labelClasses)}
+        icon={
+          showIconProfile && (
+            <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} />
+          )
+        }
         iconPosition={showIconProfile ? 'left' : 'right'}
         onClick={onProfileIconClick}
       >

--- a/react/components/PasswordInput.js
+++ b/react/components/PasswordInput.js
@@ -3,11 +3,35 @@ import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 
 import { Input } from 'vtex.styleguide'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { IconEyeSight } from 'vtex.store-icons'
+import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
 
 import { translate } from '../utils/translate'
 import PasswordValidationContent from './PasswordValidationContent'
 import TooltipVerification from './TooltipVerification'
+
+const SuffixIcon = ({ handleEyeIcon, showPassword }) => {
+  const hasIconBlock = Boolean(useChildBlock({ id: 'icon-eye-sight' }))
+
+  return (
+    <span className="pointer" onClick={handleEyeIcon}>
+      {hasIconBlock ? (
+        <ExtensionPoint
+          id="icon-eye-sight"
+          type="filled"
+          state={showPassword ? 'off' : 'on'}
+          size={16}
+        />
+      ) : (
+        <IconEyeSight
+          type="filled"
+          state={showPassword ? 'off' : 'on'}
+          size={16}
+        />
+      )}
+    </span>
+  )
+}
 
 class PasswordInput extends Component {
   constructor(props) {
@@ -104,14 +128,10 @@ class PasswordInput extends Component {
           }
           onFocus={() => this.setState({ showVerification: true })}
           suffixIcon={
-            <span className="pointer" onClick={this.handleEyeIcon}>
-              <ExtensionPoint
-                id="icon-eye-sight"
-                type="filled"
-                state={showPassword ? 'off' : 'on'}
-                size={16}
-              />
-            </span>
+            <SuffixIcon
+              showPassword={showPassword}
+              handleEyeIcon={this.handleEyeIcon}
+            />
           }
         />
         {showVerification &&

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,8 +1,0 @@
-{
-  "login": {
-    "blocks": ["icon-profile", "icon-eye-sight", "icon-arrow-back"]
-  },
-  "login-content": {
-    "blocks": ["icon-profile", "icon-eye-sight", "icon-arrow-back"]
-  }
-}


### PR DESCRIPTION
#### What is the purpose of this pull request?

This introduces a check for the existence of `icon` blocks passed to login blocks. 

#### What problem is this solving?

Avoid scenarios where the icons would not render if no icon blocks were passed by the user.

#### How should this be manually tested?

[Workspace](https://loginiconsfix--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
