### PR TITLE
Add vtex.menu to configure new links 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New extension point to customization on login popup
 
 ## [2.22.0] - 2020-01-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "vtex.store-resources": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.react-vtexid": "4.x",
-    "vtex.react-portal": "0.x"
+    "vtex.react-portal": "0.x",
+    "vtex.menu": "2.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
-import { Link } from 'vtex.render-runtime'
+import { Link, ExtensionPoint } from 'vtex.render-runtime'
 
 import { Button } from 'vtex.styleguide'
 import { AuthService } from 'vtex.react-vtexid'
@@ -14,7 +14,7 @@ class AccountOptions extends Component {
     /** Intl object*/
     intl: intlShape,
   }
-
+  
   render() {
     const { intl } = this.props
     return (
@@ -31,7 +31,7 @@ class AccountOptions extends Component {
             </button>
           </Link>
         </div>
-        <hr className="mv2 o-30" />
+        <ExtensionPoint id="menu" />
         <div className="ma4 min-h-2 b--muted-4">
           <AuthService.RedirectLogout returnUrl="/">
             {({ action: logout }) => (

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -6,7 +6,8 @@
       "user-identifier",
       "icon-profile",
       "icon-eye-sight",
-      "icon-arrow-back"
+      "icon-arrow-back",
+      "menu"
     ]
   },
   "login-content": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add vtex.menu to allow personalized links to My Account.

#### What problem is this solving?
Lack of links. In some cases the customers want other links like to "My Orders" pages..

#### How should this be manually tested?
1. Enter in https://loginmenu--unimarcdev.myvtex.com/login and do a login
2. Click at the Header link to open the Login popup

#### Screenshots or example usage
Example:
![image](https://user-images.githubusercontent.com/49173685/72746368-b36fcf00-3b90-11ea-91ff-965a62f2a5e3.png)

Blocks:
```
{
  "login": {
    "blocks": [
      "menu#additional-links"
    ],
    "props": {
      "defaultOption": 1,
      "isInitialScreenOptionOnly": false,
      "contentAlwaysWithOptions": true,
      "showPasswordVerificationIntoTooltip": false
    }
  },
  "menu#additional-links": {
    "children": [
      "menu-item#my-orders",
      "menu-item#my-lists"
    ],
    "props": {
      "blockClass": "login-menu"
    }
  },
  "menu-item#my-lists": {
    "props": {
      "id": "my-lists",
      "type": "custom",
      "highlight": false,
      "itemProps": {
        "type": "internal",
        "href": "/account#/listas",
        "noFollow": false,
        "tagTitle": "Mis listas",
        "text": "Mis listas"
      }
    }
  },
  "menu-item#my-orders": {
    "props": {
      "id": "my-orders",
      "type": "custom",
      "highlight": false,
      "itemProps": {
        "type": "internal",
        "href": "/account#/listas",
        "noFollow": false,
        "tagTitle": "Mis pedidos",
        "text": "Mis pedidos"
      }
    }
  }
}
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
