### PR TITLE
Fix/ch31230/site editor form ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- The `Identifier input placeholder` and `Invalid identifier error` site-editor form fields were not coming right after the `Identifier extension` toggle.
+
 ## [2.23.1] - 2020-02-06
 
 ## [2.23.0] - 2020-02-04

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.23.1",
+  "version": "2.23.2-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/Login.js
+++ b/react/Login.js
@@ -42,7 +42,9 @@ export default class Login extends Component {
     this.getSessionPromiseFromWindow().then(data => {
       const sessionResponse = (data || {}).response
       const sessionProfile = getProfile(sessionResponse)
-      if (sessionProfile)this.setState({ sessionProfile })
+      if (sessionProfile) {
+        this.setState({ sessionProfile })
+      }
     })
   }
 

--- a/react/Login.js
+++ b/react/Login.js
@@ -42,7 +42,7 @@ export default class Login extends Component {
     this.getSessionPromiseFromWindow().then(data => {
       const sessionResponse = (data || {}).response
       const sessionProfile = getProfile(sessionResponse)
-      if (sessionProfile) this.setState({ sessionProfile })
+      if (sessionProfile)this.setState({ sessionProfile })
     })
   }
 
@@ -101,5 +101,9 @@ Login.getSchema = () => ({
     },
   },
 })
+
+Login.uiSchema = {
+  'ui:order': ['*', 'hasIdentifierExtension', 'identifierPlaceholder', 'invalidIdentifierError'],
+}
 
 const LoginWithSession = withSession({ renderWhileLoading: true })(injectIntl(LoginComponent))

--- a/react/LoginContent.js
+++ b/react/LoginContent.js
@@ -2,6 +2,7 @@ import React, { Component, Suspense } from 'react'
 import LoginContent from './components/LoginContent'
 import { NoSSR } from 'vtex.render-runtime'
 import Loading from './components/Loading'
+import { LoginSchema } from './schema'
 
 const LoginContentWrapper = props => {
   return (

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -19,7 +19,6 @@ import OAuthAutoRedirect from './OAuthAutoRedirect'
 import { steps } from '../utils/steps'
 import { setCookie } from '../utils/set-cookie'
 
-import { LoginSchema } from '../schema'
 import { LoginPropTypes } from '../propTypes'
 import { getProfile } from '../utils/profile'
 import { session } from 'vtex.store-resources/Queries'
@@ -391,9 +390,9 @@ class LoginContent extends Component {
               <div className={formClassName}>
                 {this.shouldRenderForm && renderForm ? (
                   /** If it renders both the form and the menu, wrap the
-                   * form in a Suspense, so it doesn't hide the options 
+                   * form in a Suspense, so it doesn't hide the options
                    * while it's loading */
-                  this.shouldRenderLoginOptions ? ( 
+                  this.shouldRenderLoginOptions ? (
                     <Suspense fallback={<Loading />}>
                       {renderForm()}
                     </Suspense>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the order of Site-Editor form fields that should come one after the other

#### What problem is this solving?
This sticks the three fields together. The first field is a toggle that displays two inputs when active. Both the inputs should come right after the toggle in the form.

#### How should this be manually tested?

Go to
https://rafaprtest--storecomponents.myvtex.com/admin/cms/site-editor
And click `Login` in the right sidebar. Then, scroll until you find the `Email/Password user identifier extension` toggle and turn it on. You should see two inputs appear right below it.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/73980531-2908c880-490f-11ea-8014-5b25aad51886.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
