### PR TITLE
import session query directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Import session query directly, import less JS.
 
 ## [2.23.2] - 2020-02-11
 

--- a/react/__mocks__/vtex.store-resources/Queries.js
+++ b/react/__mocks__/vtex.store-resources/Queries.js
@@ -1,1 +1,0 @@
-export const session = {}

--- a/react/__mocks__/vtex.store-resources/QuerySession.js
+++ b/react/__mocks__/vtex.store-resources/QuerySession.js
@@ -1,0 +1,2 @@
+const session = {}
+export default session

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -21,7 +21,7 @@ import { setCookie } from '../utils/set-cookie'
 
 import { LoginPropTypes } from '../propTypes'
 import { getProfile } from '../utils/profile'
-import { session } from 'vtex.store-resources/Queries'
+import session from 'vtex.store-resources/QuerySession'
 import { AuthStateLazy } from 'vtex.react-vtexid'
 import { SELF_APP_NAME_AND_VERSION } from '../common/global'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Importing the whole `Queries` file proved to be a bad decision, performance wise. We downloaded a lot of unneeded JS files. By importing like `import { session } from 'vtex.store-resources/Queries'` we were also downloading JS of unused queries like `productSearchV2`, `productQuery` etc.

The query files are really big, so this adds up and compromises performance.

From now on, query files should be imported directly in IO apps.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
