### PR TITLE
Use location.href as returnUrl for logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The logout `returnUrl` is now set to `location.href`.
+
 ## [2.24.0] - 2020-02-19
 
 ### Added

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -33,7 +33,7 @@ class AccountOptions extends Component {
         </div>
         <hr className="mv2 o-30" />
         <div className="ma4 min-h-2 b--muted-4">
-          <AuthServiceLazy.RedirectLogout returnUrl="/">
+          <AuthServiceLazy.RedirectLogout returnUrl={window ? window.location.href : '/'}>
             {({ action: logout }) => (
               <Button
                 variation="tertiary"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use location.href as returnUrl for logout

#### What problem is this solving?
Store using rootpath (e.g.: `/us`, `/pt`) are showing erroneous behavior due to the current redirect to `/`.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.