### PR TITLE
Feature/myaccount links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `mirrorTooltipToRight`'s default prop value
+
+### Added
+
+- `accountOptionLinks` prop to the `login` interface
+- `accountOptionLinks` prop to the site-editor
+
 ## [2.24.0] - 2020-02-19
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 | `invalidIdentifierError`                           | `String`  | Set error message for invalid user identifier                                                 | -             |
 | `mirrorTooltipToRight`                             | `Boolean` | Makes login tooltip open towards the right side                                               | -             |
 | `logInButtonBehavior`                              | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page | "popover"     |
-| `accountOptionLinks`                               | `Array`   | Determines more specific account option links to replace the `My Account` link.<br>Each array element is an object with the properties:<br><ul><li>`label` - Link text</li><li>`path` - Relative path to where the link leads</li></ul> | -             |
+| `accountOptionLinks`                               | `Array`   | Determines more specific account option links to replace the `My Account` link.<br>Each array element is an object with the properties:<br><ul><li>`label` [`string`] - Link text</li><li>`path` [`string`] - Relative path to where the link leads</li><li>`cssClass` [`string`] - CSS class the link receives</li></ul> | -             |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,25 +94,26 @@ For now these blocks do not have any required or optional blocks.
 
 Through the Storefront, you can change the `login`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name                                          | Type      | Description                                                                                | Default value |
-| -------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------ | ------------- |
-| `optionsTitle`                                     | `String`  | Set title of login options                                                                 | -             |
-| `emailAndPasswordTitle`                            | `String`  | Set title of login with email and password                                                 | -             |
-| `accessCodeTitle`                                  | `String`  | Set title of login by access code                                                          | -             |
-| `emailPlaceholder`                                 | `String`  | Set placeholder to email input                                                             | -             |
-| `passwordPlaceholder`                              | `String`  | Set placeholder to password input                                                          | -             |
-| `showPasswordVerificationIntoTooltip`              | `Boolean` | Set show password format verification as tooltip                                           | -             |
-| `acessCodePlaceholder`                             | `String`  | Set placeholder to access code input                                                       | -             |
-| `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                 | -             |
-| `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                               | -             |
-| `iconLabel`                                        | `String`  | Set label of the login button                                                              | -             |
-| `labelClasses`                                     | `String`  | Label's classnames                                                                         | -             |
-| `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                             | -             |
-| `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                | -             |
-| `identifierPlaceholder`                            | `String`  | Set placeholder for the identifier extension                                               | -             |
-| `invalidIdentifierError`                           | `String`  | Set error message for invalid user identifier                                              | -             |
-| `mirrorTooltipToRight`                             | `Boolean` | Makes login tooltip open towards the right side                                            | -             |
-| `logInButtonBehavior`                              | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page  | "popover"     |
+| Prop name                                          | Type      | Description                                                                                   | Default value |
+| -------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
+| `optionsTitle`                                     | `String`  | Set title of login options                                                                    | -             |
+| `emailAndPasswordTitle`                            | `String`  | Set title of login with email and password                                                    | -             |
+| `accessCodeTitle`                                  | `String`  | Set title of login by access code                                                             | -             |
+| `emailPlaceholder`                                 | `String`  | Set placeholder to email input                                                                | -             |
+| `passwordPlaceholder`                              | `String`  | Set placeholder to password input                                                             | -             |
+| `showPasswordVerificationIntoTooltip`              | `Boolean` | Set show password format verification as tooltip                                              | -             |
+| `acessCodePlaceholder`                             | `String`  | Set placeholder to access code input                                                          | -             |
+| `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                    | -             |
+| `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                                  | -             |
+| `iconLabel`                                        | `String`  | Set label of the login button                                                                 | -             |
+| `labelClasses`                                     | `String`  | Label's classnames                                                                            | -             |
+| `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                                | -             |
+| `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                   | -             |
+| `identifierPlaceholder`                            | `String`  | Set placeholder for the identifier extension                                                  | -             |
+| `invalidIdentifierError`                           | `String`  | Set error message for invalid user identifier                                                 | -             |
+| `mirrorTooltipToRight`                             | `Boolean` | Makes login tooltip open towards the right side                                               | -             |
+| `logInButtonBehavior`                              | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page | "popover"     |
+| `accountOptionLinks`                               | `Array`   | Determines more specific account option links to replace the `My Account` link.<br>Each array element is an object with the properties:<br><ul><li>`label` - Link text</li><li>`path` - Relative path to where the link leads</li></ul> | -             |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "vtex.store-resources": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.react-vtexid": "4.x",
-    "vtex.react-portal": "0.x"
+    "vtex.react-portal": "0.x",
+    "vtex.css-handles": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.24.0",
+  "version": "2.25.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/context.json
+++ b/messages/context.json
@@ -53,5 +53,9 @@
   "admin/editor.login.identifierPlaceholder": "admin/editor.login.identifierPlaceholder",
   "admin/editor.login.invalidIdentifierError": "admin/editor.login.invalidIdentifierError",
   "admin/editor.login.mirrorTooltipToRightTitle": "admin/editor.login.mirrorTooltipToRightTitle",
-  "admin/editor.login.logInButtonBehavior": "admin/editor.login.logInButtonBehavior"
+  "admin/editor.login.logInButtonBehavior": "admin/editor.login.logInButtonBehavior",
+  "admin/editor.login.accountOptionLinks": "admin/editor.login.accountOptionLinks",
+  "admin/editor.login.accountOptionLabelTitle": "admin/editor.login.accountOptionLabelTitle",
+  "admin/editor.login.accountOptionPathTitle": "admin/editor.login.accountOptionPathTitle",
+  "admin/editor.login.accountOptionCssClassTitle": "admin/editor.login.accountOptionCssClassTitle"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -53,5 +53,9 @@
   "admin/editor.login.identifierPlaceholder": "Identifier input placeholder",
   "admin/editor.login.invalidIdentifierError": "Invalid identifier error",
   "admin/editor.login.mirrorTooltipToRightTitle": "Mirror tooltip to right",
-  "admin/editor.login.logInButtonBehavior": "Log in button behavior"
+  "admin/editor.login.logInButtonBehavior": "Log in button behavior",
+  "admin/editor.login.accountOptionLinks": "Account Option Links",
+  "admin/editor.login.accountOptionLabelTitle": "Label",
+  "admin/editor.login.accountOptionPathTitle": "Path",
+  "admin/editor.login.accountOptionCssClassTitle": "CSS Class"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -53,5 +53,9 @@
   "admin/editor.login.identifierPlaceholder": "Placeholder del campo de identificador",
   "admin/editor.login.invalidIdentifierError": "Error de identificador inválido",
   "admin/editor.login.mirrorTooltipToRightTitle": "Reflejar tooltip a la derecha",
-  "admin/editor.login.logInButtonBehavior": "Comportamiento del botón de login"
+  "admin/editor.login.logInButtonBehavior": "Comportamiento del botón de login",
+  "admin/editor.login.accountOptionLinks": "Enlaces de Opción de la Cuenta",
+  "admin/editor.login.accountOptionLabelTitle": "Label",
+  "admin/editor.login.accountOptionPathTitle": "Path",
+  "admin/editor.login.accountOptionCssClassTitle": "Clase CSS"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -53,5 +53,9 @@
   "admin/editor.login.identifierPlaceholder": "Placeholder do campo de identificador",
   "admin/editor.login.invalidIdentifierError": "Erro de identificador inválido",
   "admin/editor.login.mirrorTooltipToRightTitle": "Espelhar tooltip para a direita",
-  "admin/editor.login.logInButtonBehavior": "Comportamento do botão de login"
+  "admin/editor.login.logInButtonBehavior": "Comportamento do botão de login",
+  "admin/editor.login.accountOptionLinks": "Links de Opção da Conta",
+  "admin/editor.login.accountOptionLabelTitle": "Label",
+  "admin/editor.login.accountOptionPathTitle": "Path",
+  "admin/editor.login.accountOptionCssClassTitle": "Classe CSS"
 }

--- a/react/Login.js
+++ b/react/Login.js
@@ -104,7 +104,7 @@ Login.getSchema = () => ({
     mirrorTooltipToRight: {
       title: 'admin/editor.login.mirrorTooltipToRightTitle',
       type: 'boolean',
-      default: 'false',
+      default: false,
     },
     logInButtonBehavior: {
       title: 'admin/editor.login.logInButtonBehavior',

--- a/react/Login.js
+++ b/react/Login.js
@@ -112,11 +112,32 @@ Login.getSchema = () => ({
       enum: [LogInButtonBehavior.POPOVER, LogInButtonBehavior.LINK],
       default: LogInButtonBehavior.POPOVER,
     },
+    accountOptionLinks: {
+      title: 'admin/editor.login.accountOptionLinks',
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          label: {
+            title: 'admin/editor.login.accountOptionLabelTitle',
+            type: 'string'
+          },
+          path: {
+            title: 'admin/editor.login.accountOptionPathTitle',
+            type: 'string'
+          },
+          cssClass: {
+            title: 'admin/editor.login.accountOptionCssClassTitle',
+            type: 'string'
+          }
+        }
+      }
+    }
   },
 })
 
 Login.uiSchema = {
-  'ui:order': ['*', 'hasIdentifierExtension', 'identifierPlaceholder', 'invalidIdentifierError'],
+  'ui:order': ['*', 'hasIdentifierExtension', 'identifierPlaceholder', 'invalidIdentifierError', 'accountOptionLinks'],
 }
 
 const LoginWithSession = withSession({ renderWhileLoading: true })(injectIntl(LoginComponent))

--- a/react/__mocks__/vtex.css-handles.js
+++ b/react/__mocks__/vtex.css-handles.js
@@ -1,0 +1,1 @@
+export const useCssHandles = () => ({})

--- a/react/__tests__/__snapshots__/Login.test.js.snap
+++ b/react/__tests__/__snapshots__/Login.test.js.snap
@@ -60,9 +60,11 @@ exports[`<Login /> component should match snapshot when loading 1`] = `
     </div>
   </div>
 </DocumentFragment>
-`;
+`
 
-exports[`<Login /> component should match snapshot with profile with name 1`] = `
+exports[
+  `<Login /> component should match snapshot with profile with name 1`
+] = `
 <DocumentFragment>
   <div
     class="container flex items-center fr"
@@ -100,14 +102,14 @@ exports[`<Login /> component should match snapshot with profile with name 1`] = 
                 class="content flex relative bg-base justify-around overflow-visible pa4 center items-start-ns contentInitialScreen items-baseline"
               >
                 <div
-                  class="contentForm dn ph4 pb6 contentFormVisible db "
+                  class="contentForm dn ph4 contentFormVisible db "
                 >
                   <div>
                     <div
                       class="accountOptions items-center w-100"
                     >
                       <div
-                        class="ma4 min-h-2 b--muted-4"
+                        class="mv4 min-h-2 b--muted-4"
                       >
                         <a
                           href="store.account"
@@ -128,7 +130,7 @@ exports[`<Login /> component should match snapshot with profile with name 1`] = 
                         class="mv2 o-30"
                       />
                       <div
-                        class="ma4 min-h-2 b--muted-4"
+                        class="mv4 min-h-2 b--muted-4"
                       >
                         <button
                           class="Button-mock"
@@ -152,9 +154,11 @@ exports[`<Login /> component should match snapshot with profile with name 1`] = 
     </div>
   </div>
 </DocumentFragment>
-`;
+`
 
-exports[`<Login /> component should match snapshot with profile without name 1`] = `
+exports[
+  `<Login /> component should match snapshot with profile without name 1`
+] = `
 <DocumentFragment>
   <div
     class="container flex items-center fr"
@@ -192,14 +196,14 @@ exports[`<Login /> component should match snapshot with profile without name 1`]
                 class="content flex relative bg-base justify-around overflow-visible pa4 center items-start-ns contentInitialScreen items-baseline"
               >
                 <div
-                  class="contentForm dn ph4 pb6 contentFormVisible db "
+                  class="contentForm dn ph4 contentFormVisible db "
                 >
                   <div>
                     <div
                       class="accountOptions items-center w-100"
                     >
                       <div
-                        class="ma4 min-h-2 b--muted-4"
+                        class="mv4 min-h-2 b--muted-4"
                       >
                         <a
                           href="store.account"
@@ -220,7 +224,7 @@ exports[`<Login /> component should match snapshot with profile without name 1`]
                         class="mv2 o-30"
                       />
                       <div
-                        class="ma4 min-h-2 b--muted-4"
+                        class="mv4 min-h-2 b--muted-4"
                       >
                         <button
                           class="Button-mock"
@@ -244,7 +248,7 @@ exports[`<Login /> component should match snapshot with profile without name 1`]
     </div>
   </div>
 </DocumentFragment>
-`;
+`
 
 exports[`<Login /> component should match snapshot without profile 1`] = `
 <DocumentFragment>
@@ -392,7 +396,7 @@ exports[`<Login /> component should match snapshot without profile 1`] = `
                   </div>
                 </div>
                 <div
-                  class="contentForm dn ph4 pb6"
+                  class="contentForm dn ph4"
                 />
               </div>
             </div>
@@ -402,4 +406,4 @@ exports[`<Login /> component should match snapshot without profile 1`] = `
     </div>
   </div>
 </DocumentFragment>
-`;
+`

--- a/react/__tests__/__snapshots__/LoginContent.test.js.snap
+++ b/react/__tests__/__snapshots__/LoginContent.test.js.snap
@@ -114,11 +114,11 @@ exports[`<LoginContent /> component should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="contentForm dn ph4 pb6"
+      class="contentForm dn ph4"
     />
   </div>
 </DocumentFragment>
-`;
+`
 
 exports[`<LoginContent /> component should match snapshot when loading 1`] = `
 <DocumentFragment>
@@ -234,8 +234,8 @@ exports[`<LoginContent /> component should match snapshot when loading 1`] = `
       </div>
     </div>
     <div
-      class="contentForm dn ph4 pb6"
+      class="contentForm dn ph4"
     />
   </div>
 </DocumentFragment>
-`;
+`

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -28,7 +28,9 @@ const AccountOptions = ({ intl, optionLinks }) => {
       <div className="ma4 min-h-2 b--muted-4">
         {optionLinks && optionLinks.length > 0 ? (
           <>
-            <div className="t-small b pb4">
+            <div
+              className={`${styles.accountOptionsSectionTitle} t-small b pb4`}
+            >
               {translate('store/login.myAccount', intl)}
             </div>
             {optionLinks.map(({ label, path, cssClass }, inx) => (
@@ -62,7 +64,7 @@ const AccountOptions = ({ intl, optionLinks }) => {
             if (hasOptionLinks) {
               return (
                 <button
-                  className="t-small bn pa0 c-muted-1 hover-c-danger pointer"
+                  className={`${styles.logoutButton} t-small bn pa0 c-muted-1 hover-c-danger pointer`}
                   onClick={logout}
                 >
                   {translate('store/login.logoutLabel', intl)}

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -1,8 +1,7 @@
-import React, { Component } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import { Link } from 'vtex.render-runtime'
-
 import { Button } from 'vtex.styleguide'
 import { AuthServiceLazy } from 'vtex.react-vtexid'
 
@@ -10,78 +9,73 @@ import { translate } from '../utils/translate'
 import styles from '../styles.css'
 
 // Component that shows account options to the user.
-class AccountOptions extends Component {
-  static propTypes = {
-    /** Intl object*/
-    intl: intlShape,
-    optionLinks: PropTypes.array,
-  }
+const AccountOptions = ({ intl, optionLinks }) => {
+  const hasOptionLinks = useMemo(() => optionLinks && optionLinks.length > 0, [
+    optionLinks,
+  ])
 
-  render() {
-    const { intl, optionLinks } = this.props
-
-    const hasOptionLinks = optionLinks && optionLinks.length > 0
-
-    return (
-      <div className={`${styles.accountOptions} items-center w-100`}>
-        <div className="ma4 min-h-2 b--muted-4">
-          {optionLinks && optionLinks.length > 0 ?
-            <>
-              <div className="t-small b pb4">
+  return (
+    <div className={`${styles.accountOptions} items-center w-100`}>
+      <div className="ma4 min-h-2 b--muted-4">
+        {optionLinks && optionLinks.length > 0 ? (
+          <>
+            <div className="t-small b pb4">
+              {translate('store/login.myAccount', intl)}
+            </div>
+            {optionLinks.map(({ label, path }) => (
+              <a
+                className="db no-underline t-small c-muted-1 hover-c-action-primary pb3"
+                href={new URL(path || '/', window.location.href).href}
+              >
+                {label}
+              </a>
+            ))}
+          </>
+        ) : (
+          <Link page="store.account">
+            <button
+              className={`${styles.button} bw1 ba ttu br2 t-action--small v-mid relative pv3 ph5 t-heading-5 bg-base b--transparent c-action-primary  hover-c-action-primary pointer`}
+              closeonclick=""
+            >
+              <span className="t-action--small">
                 {translate('store/login.myAccount', intl)}
-              </div>
-              {optionLinks.map(({ label, path }) =>
-                <a
-                  className={'db no-underline t-small c-muted-1 hover-c-action-primary pb3'}
-                  href={new URL(path || '/', window.location.href).href}
-                >
-                  {label}
-                </a>
-              )}
-            </>
-          :
-            <Link page={'store.account'}>
-              <button
-                className={`${styles.button} bw1 ba ttu br2 t-action--small v-mid relative pv3 ph5 t-heading-5 bg-base b--transparent c-action-primary  hover-c-action-primary pointer`}
-                closeonclick=""
-              >
-                <span className="t-action--small">
-                  {translate('store/login.myAccount', intl)}
-                </span>
-              </button>
-            </Link>
-          }
-        </div>
-        <hr className="mv2 o-30" />
-        <div className="ma4 min-h-2 b--muted-4">
-          <AuthServiceLazy.RedirectLogout returnUrl="/">
-            {({ action: logout }) => {
-              if (hasOptionLinks) {
-                return (
-                  <button
-                    className="t-small bn pa0 c-muted-1 hover-c-danger pointer"
-                    onClick={logout}
-                  >
-                    {translate('store/login.logoutLabel', intl)}
-                  </button>
-                )
-              }
+              </span>
+            </button>
+          </Link>
+        )}
+      </div>
+      <hr className="mv2 o-30" />
+      <div className="ma4 min-h-2 b--muted-4">
+        <AuthServiceLazy.RedirectLogout returnUrl="/">
+          {({ action: logout }) => {
+            if (hasOptionLinks) {
               return (
-              <Button
-                variation="tertiary"
-                size="small"
-                onClick={logout}
-              >
+                <button
+                  className="t-small bn pa0 c-muted-1 hover-c-danger pointer"
+                  onClick={logout}
+                >
+                  {translate('store/login.logoutLabel', intl)}
+                </button>
+              )
+            }
+            return (
+              <Button variation="tertiary" size="small" onClick={logout}>
                 <span className="t-action--small">
                   {translate('store/login.logoutLabel', intl)}
                 </span>
               </Button>
-            )}}
-          </AuthServiceLazy.RedirectLogout>
-        </div>
+            )
+          }}
+        </AuthServiceLazy.RedirectLogout>
       </div>
-    )
-  }
+    </div>
+  )
+}
+
+AccountOptions.propTypes = {
+  /** Intl object */
+  intl: intlShape,
+  optionLinks: PropTypes.array,
 }
 
 export default injectIntl(AccountOptions)

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -4,6 +4,7 @@ import { injectIntl, intlShape } from 'react-intl'
 import { Link } from 'vtex.render-runtime'
 import { Button } from 'vtex.styleguide'
 import { AuthServiceLazy } from 'vtex.react-vtexid'
+import { useCssHandles } from 'vtex.css-handles'
 
 import { translate } from '../utils/translate'
 import styles from '../styles.css'
@@ -14,6 +15,14 @@ const AccountOptions = ({ intl, optionLinks }) => {
     optionLinks,
   ])
 
+  const cssClasses = useMemo(() => {
+    return optionLinks
+      .map(({ cssClass }) => cssClass)
+      .filter(cssClass => cssClass)
+  }, [optionLinks])
+
+  const handles = useCssHandles(cssClasses)
+
   return (
     <div className={`${styles.accountOptions} items-center w-100`}>
       <div className="ma4 min-h-2 b--muted-4">
@@ -22,9 +31,10 @@ const AccountOptions = ({ intl, optionLinks }) => {
             <div className="t-small b pb4">
               {translate('store/login.myAccount', intl)}
             </div>
-            {optionLinks.map(({ label, path }, inx) => (
+            {optionLinks.map(({ label, path, cssClass }, inx) => (
               <a
-                className="db no-underline t-small c-muted-1 hover-c-action-primary pb3"
+                className={`${handles[cssClass] ||
+                  ''} db no-underline t-small c-muted-1 hover-c-action-primary pb3`}
                 href={new URL(path || '/', window.location.href).href}
                 key={inx}
               >

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -22,10 +22,11 @@ const AccountOptions = ({ intl, optionLinks }) => {
             <div className="t-small b pb4">
               {translate('store/login.myAccount', intl)}
             </div>
-            {optionLinks.map(({ label, path }) => (
+            {optionLinks.map(({ label, path }, inx) => (
               <a
                 className="db no-underline t-small c-muted-1 hover-c-action-primary pb3"
                 href={new URL(path || '/', window.location.href).href}
+                key={inx}
               >
                 {label}
               </a>

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -16,7 +16,7 @@ const AccountOptions = ({ intl, optionLinks }) => {
   ])
 
   const cssClasses = useMemo(() => {
-    return optionLinks
+    return (optionLinks || [])
       .map(({ cssClass }) => cssClass)
       .filter(cssClass => cssClass)
   }, [optionLinks])
@@ -26,7 +26,7 @@ const AccountOptions = ({ intl, optionLinks }) => {
   return (
     <div className={`${styles.accountOptions} items-center w-100`}>
       <div className="ma4 min-h-2 b--muted-4">
-        {optionLinks && optionLinks.length > 0 ? (
+        {hasOptionLinks ? (
           <>
             <div
               className={`${styles.accountOptionsSectionTitle} t-small b pb4`}

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -25,18 +25,18 @@ const AccountOptions = ({ intl, optionLinks }) => {
 
   return (
     <div className={`${styles.accountOptions} items-center w-100`}>
-      <div className="ma4 min-h-2 b--muted-4">
+      <div className="mv4 min-h-2 b--muted-4">
         {hasOptionLinks ? (
           <>
             <div
-              className={`${styles.accountOptionsSectionTitle} t-small b pb4`}
+              className={`${styles.accountOptionsSectionTitle} t-small b mb3`}
             >
               {translate('store/login.myAccount', intl)}
             </div>
             {optionLinks.map(({ label, path, cssClass }, inx) => (
               <a
                 className={`${handles[cssClass] ||
-                  ''} db no-underline t-small c-muted-1 hover-c-action-primary pb3`}
+                  ''} db no-underline t-small c-muted-1 hover-c-action-primary pv3`}
                 href={new URL(path || '/', window.location.href).href}
                 key={inx}
               >
@@ -58,7 +58,7 @@ const AccountOptions = ({ intl, optionLinks }) => {
         )}
       </div>
       <hr className="mv2 o-30" />
-      <div className="ma4 min-h-2 b--muted-4">
+      <div className="mv4 min-h-2 b--muted-4">
         <AuthServiceLazy.RedirectLogout returnUrl="/">
           {({ action: logout }) => {
             if (hasOptionLinks) {

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import { Link } from 'vtex.render-runtime'
 
@@ -13,28 +14,59 @@ class AccountOptions extends Component {
   static propTypes = {
     /** Intl object*/
     intl: intlShape,
+    optionLinks: PropTypes.array,
   }
 
   render() {
-    const { intl } = this.props
+    const { intl, optionLinks } = this.props
+
+    const hasOptionLinks = optionLinks && optionLinks.length > 0
+
     return (
       <div className={`${styles.accountOptions} items-center w-100`}>
         <div className="ma4 min-h-2 b--muted-4">
-          <Link page={'store.account'}>
-            <button
-              className={`${styles.button} bw1 ba ttu br2 t-action--small v-mid relative pv3 ph5 t-heading-5 bg-base b--transparent c-action-primary  hover-c-action-primary pointer`}
-              closeonclick=""
-            >
-              <span className="t-action--small">
+          {optionLinks && optionLinks.length > 0 ?
+            <>
+              <div className="t-small b pb4">
                 {translate('store/login.myAccount', intl)}
-              </span>
-            </button>
-          </Link>
+              </div>
+              {optionLinks.map(({ label, path }) =>
+                <a
+                  className={'db no-underline t-small c-muted-1 hover-c-action-primary pb3'}
+                  href={new URL(path || '/', window.location.href).href}
+                >
+                  {label}
+                </a>
+              )}
+            </>
+          :
+            <Link page={'store.account'}>
+              <button
+                className={`${styles.button} bw1 ba ttu br2 t-action--small v-mid relative pv3 ph5 t-heading-5 bg-base b--transparent c-action-primary  hover-c-action-primary pointer`}
+                closeonclick=""
+              >
+                <span className="t-action--small">
+                  {translate('store/login.myAccount', intl)}
+                </span>
+              </button>
+            </Link>
+          }
         </div>
         <hr className="mv2 o-30" />
         <div className="ma4 min-h-2 b--muted-4">
           <AuthServiceLazy.RedirectLogout returnUrl="/">
-            {({ action: logout }) => (
+            {({ action: logout }) => {
+              if (hasOptionLinks) {
+                return (
+                  <button
+                    className="t-small bn pa0 c-muted-1 hover-c-danger pointer"
+                    onClick={logout}
+                  >
+                    {translate('store/login.logoutLabel', intl)}
+                  </button>
+                )
+              }
+              return (
               <Button
                 variation="tertiary"
                 size="small"
@@ -44,7 +76,7 @@ class AccountOptions extends Component {
                   {translate('store/login.logoutLabel', intl)}
                 </span>
               </Button>
-            )}
+            )}}
           </AuthServiceLazy.RedirectLogout>
         </div>
       </div>

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -78,10 +78,10 @@ const STEPS = [
       </div>
     )
   },
-  () => {
+  (props) => {
     return style => (
       <div style={style} key={3}>
-        <AccountOptions />
+        <AccountOptions optionLinks={props.accountOptionLinks} />
       </div>
     )
   },

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -371,7 +371,7 @@ class LoginContent extends Component {
       }
     )
 
-    const formClassName = classNames(styles.contentForm, 'dn ph4 pb6', {
+    const formClassName = classNames(styles.contentForm, 'dn ph4', {
       [`${styles.contentFormVisible} db `]: this.shouldRenderForm,
     })
 

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -36,10 +36,12 @@ export const LoginContainerProptypes = {
   mirrorTooltipToRight: PropTypes.bool,
   /** Determines what happens when the log in button is pressed */
   logInButtonBehavior: PropTypes.string,
+  /** Determines more specific account option buttons to replace the "My Account" button */
+  accountOptionLinks: PropTypes.array,
 }
 
 export const LoginPropTypes = {
-  /** Intl object*/
+  /** Intl object */
   intl: intlShape,
   /** User profile information */
   profile: PropTypes.shape({}),
@@ -47,9 +49,9 @@ export const LoginPropTypes = {
   isBoxOpen: PropTypes.bool.isRequired,
   /** Should the Login Button be rendered as link or not */
   loginButtonAsLink: PropTypes.bool.isRequired,
-  /** Function called when the user click outside of the box*/
+  /** Function called when the user click outside of the box */
   onOutSideBoxClick: PropTypes.func.isRequired,
-  /** Function called when the user clicks on the icon*/
+  /** Function called when the user clicks on the icon */
   onProfileIconClick: PropTypes.func.isRequired,
   /** Runtime context. */
   runtime: PropTypes.shape({

--- a/react/styles.css
+++ b/react/styles.css
@@ -74,6 +74,10 @@
 
 .codeConfirmation {}
 
+.accountOptionsSectionTitle {}
+
+.logoutButton {}
+
 .formTitle {
   white-space: pre-line;
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the prop `accountOptionLinks` to the login block, implementing the layout designed [here](https://www.figma.com/file/9RHq1aYRC5oyMqnUry2xRj/Authentication-Store?node-id=769%3A0).

![image](https://user-images.githubusercontent.com/22064061/76017984-47f27e80-5efe-11ea-87c8-8940f18912ed.png)

#### What problem is this solving?
This implements the `accountOptionLinks` prop, adds it to the `site-editor` and other minor fixes

#### How should this be manually tested?
You can test it at
https://rafaprtest--storecomponents.myvtex.com/admin/cms/site-editor.
Open the login popover by clicking the login button in the store header. Log in to any account, then open the popover again to see the "My Account" and "Logout" buttons. Click nothing and keep the popover open.

Click in the `Login` option in the right sidebar, then scroll to the `Account Option Links` section. Then, add some option links, defining a Label, Path and CSS Class for each one, like `Profile`, `/account#/profile` and `profileClass` respectively. You should see the login popover changing, adding the links you defined. Check their CSS classes and click them to see the configurations working.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/76018969-c13ea100-5eff-11ea-973f-98d7c1bb7d46.png)

![image](https://user-images.githubusercontent.com/22064061/76019005-d0bdea00-5eff-11ea-9ec6-729005097238.png)

![image](https://user-images.githubusercontent.com/22064061/76021366-ee8d4e00-5f03-11ea-880d-1140b2bf1855.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Clubhouse Stories
[ch29513]