### PR TITLE
Fix bug of Login being invisible on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prop `showIconProfile` to be a responsive value
+- Change default of `showIconProfile` of mobile to `true`
+- Make "Sing in" text visible when `showIconProfile` is `false` and it's mobile
 
 ## [2.24.0] - 2020-02-19
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,25 +94,25 @@ For now these blocks do not have any required or optional blocks.
 
 Through the Storefront, you can change the `login`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name                                          | Type      | Description                                                                                | Default value |
-| -------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------ | ------------- |
-| `optionsTitle`                                     | `String`  | Set title of login options                                                                 | -             |
-| `emailAndPasswordTitle`                            | `String`  | Set title of login with email and password                                                 | -             |
-| `accessCodeTitle`                                  | `String`  | Set title of login by access code                                                          | -             |
-| `emailPlaceholder`                                 | `String`  | Set placeholder to email input                                                             | -             |
-| `passwordPlaceholder`                              | `String`  | Set placeholder to password input                                                          | -             |
-| `showPasswordVerificationIntoTooltip`              | `Boolean` | Set show password format verification as tooltip                                           | -             |
-| `acessCodePlaceholder`                             | `String`  | Set placeholder to access code input                                                       | -             |
-| `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                 | -             |
-| `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                               | -             |
-| `iconLabel`                                        | `String`  | Set label of the login button                                                              | -             |
-| `labelClasses`                                     | `String`  | Label's classnames                                                                         | -             |
-| `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                             | -             |
-| `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                | -             |
-| `identifierPlaceholder`                            | `String`  | Set placeholder for the identifier extension                                               | -             |
-| `invalidIdentifierError`                           | `String`  | Set error message for invalid user identifier                                              | -             |
-| `mirrorTooltipToRight`                             | `Boolean` | Makes login tooltip open towards the right side                                            | -             |
-| `logInButtonBehavior`                              | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page  | "popover"     |
+| Prop name                                         | Type      | Description                                                                                                        | Default value                          |
+| ------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| `optionsTitle`                                    | `String`  | Set title of login options                                                                                         | -                                      |
+| `emailAndPasswordTitle`                           | `String`  | Set title of login with email and password                                                                         | -                                      |
+| `accessCodeTitle`                                 | `String`  | Set title of login by access code                                                                                  | -                                      |
+| `emailPlaceholder`                                | `String`  | Set placeholder to email input                                                                                     | -                                      |
+| `passwordPlaceholder`                             | `String`  | Set placeholder to password input                                                                                  | -                                      |
+| `showPasswordVerificationIntoTooltip`             | `Boolean` | Set show password format verification as tooltip                                                                   | -                                      |
+| `acessCodePlaceholder`                            | `String`  | Set placeholder to access code input                                                                               | -                                      |
+| `showIconProfile`                                 | `Boolean` | Enables icon (`hpa-profile`). Notice that this prop is responsive, so you can specify a value for each breakpoint. | `{ "desktop": false, "mobile": true }` |
+| `iconSize` (DEPRECATED - use icon blocks instead) | `Number`  | Set size of the profile icon                                                                                       | -                                      |
+| `iconLabel`                                       | `String`  | Set label of the login button                                                                                      | -                                      |
+| `labelClasses`                                    | `String`  | Label's classnames                                                                                                 | -                                      |
+| `providerPasswordButtonLabel`                     | `String`  | Set Password login button text                                                                                     | -                                      |
+| `hasIdentifierExtension`                          | `Boolean` | Enables identifier extension configurations                                                                        | -                                      |
+| `identifierPlaceholder`                           | `String`  | Set placeholder for the identifier extension                                                                       | -                                      |
+| `invalidIdentifierError`                          | `String`  | Set error message for invalid user identifier                                                                      | -                                      |
+| `mirrorTooltipToRight`                            | `Boolean` | Makes login tooltip open towards the right side                                                                    | -                                      |
+| `logInButtonBehavior`                             | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page                      | "popover"                              |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 
@@ -139,15 +139,17 @@ This app can be extended through the `plugins.json` file of the store builder. T
 #### User Identifier Extension
 
 The Email/Password login takes two inputs:
+
 - The user email (his identifier)
 - The user password
 
-The `User Identifier Extension` allows other identifiers to be used in the login form, *as long as it can be resolved to the user email*.
+The `User Identifier Extension` allows other identifiers to be used in the login form, _as long as it can be resolved to the user email_.
 For example, if your account stores the National Identity Document of each user, the Email/Password login would be changed to ask for the following two inputs:
+
 - The user National Identity Document (his identifier)
 - The user password
 
-There is a limitation to this feature. Every user must have an email to be logged in, so the user identifier *must be able to be resolved to an email*. If you want to use an identifier other than the email, you must create a resolver app (or an extension app) that returns an email, given an identifier.
+There is a limitation to this feature. Every user must have an email to be logged in, so the user identifier _must be able to be resolved to an email_. If you want to use an identifier other than the email, you must create a resolver app (or an extension app) that returns an email, given an identifier.
 For example, imagine the user `John`, whose email is `john@example.com` and whose National Identity Document is `12345`. When he types his document (`12345`), your app must receive the `12345`, find out that it belongs to John, find out that John's email is `john@example.com` and return this email to the login app.
 
 When an extension app returns an email to the login app, it acts like the user just typed in that email. So if it returns `null`, for example, a message like `"The email is invalid"` will appear. This message, along with some others, may be edited in the Store Front, as described in the `Blocks API` section (eg. `"The User Identifier Extension is invalid"`).
@@ -157,6 +159,7 @@ When an extension app returns an email to the login app, it acts like the user j
 To create your extension app, there are five steps you must worry about.
 
 - First, you must add `login` as your app's dependency. In the `manifest.json` file:
+
 ```json
 "dependencies": {
   "vtex.login": "2.x"
@@ -164,6 +167,7 @@ To create your extension app, there are five steps you must worry about.
 ```
 
 - Second, you need to add the `store` builder to your app. In the `manifest.json` file:
+
 ```json
 "builders": {
   "store": "0.x",
@@ -171,6 +175,7 @@ To create your extension app, there are five steps you must worry about.
 ```
 
 - Third, you must extend the `user-identifier` `interface` defined by the login app. You can choose any interface name you want, which will be represented here by {{InterfaceName}}. You will need to create a component for that interface, but for now it will be represented by {{ComponentName}}. In the `store/interfaces.json` file:
+
 ```json
 "user-identifier.{{InterfaceName}}": {
   "component": "{{ComponentName}}"
@@ -178,6 +183,7 @@ To create your extension app, there are five steps you must worry about.
 ```
 
 - Fourth, you must plug in your `interface` to the login app. In the `store/plugins.json` file:
+
 ```json
 "login > user-identifier": "user-identifier.{{InterfaceName}}",
 "login-content > user-identifier": "user-identifier.{{InterfaceName}}",
@@ -188,7 +194,11 @@ To create your extension app, there are five steps you must worry about.
 ```js
 import { useState, useCallback, useEffect } from 'react'
 
-const ComponentName = ({ renderInput, identifierPlaceholder, registerSubmitter }) => {
+const ComponentName = ({
+  renderInput,
+  identifierPlaceholder,
+  registerSubmitter,
+}) => {
   // The component receives 3 props:
   // - renderInput is a function that returns the same Input component used by the login app, defined in styleguide.
   //   It receives an object with three named parameters, trivially used by Inputs with react: value, onChange, placeholder.
@@ -225,7 +235,6 @@ const ComponentName = ({ renderInput, identifierPlaceholder, registerSubmitter }
 }
 
 export default ComponentName
-
 ```
 
 After following the five steps, your extension app will be good to go. Just install it in your account and it will replace the `email` Input in the login form.
@@ -308,7 +317,7 @@ You can check if others are passing through similar issues [here](https://github
 
 ## Contributing
 
-Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project. 
+Check it out [how to contribute](https://github.com/vtex-apps/awesome-io#contributing) with this project.
 
 ## Tests
 

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,8 @@
     "vtex.store-icons": "0.x",
     "vtex.react-vtexid": "4.x",
     "vtex.react-portal": "0.x",
-    "vtex.responsive-values": "0.x"
+    "vtex.responsive-values": "0.x",
+    "vtex.device-detector": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "vtex.store-resources": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.react-vtexid": "4.x",
-    "vtex.react-portal": "0.x"
+    "vtex.react-portal": "0.x",
+    "vtex.responsive-values": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -1,18 +1,18 @@
-import React, { Component, Fragment, Suspense } from 'react'
+import React, { Fragment, Suspense } from 'react'
+import { useIntl } from 'react-intl'
+import classNames from 'classnames'
+
 import {
-  withRuntimeContext,
+  useRuntime,
   ExtensionPoint,
   useChildBlock,
 } from 'vtex.render-runtime'
-
-import classNames from 'classnames'
-
 import { IconProfile } from 'vtex.store-icons'
 import Overlay from 'vtex.react-portal/Overlay'
 import { ButtonWithIcon } from 'vtex.styleguide'
+import { useResponsiveValue } from 'vtex.responsive-values'
 
 import { truncateString } from '../utils/format-string'
-import { translate } from '../utils/translate'
 import { LoginPropTypes } from '../propTypes'
 
 import styles from '../styles.css'
@@ -40,129 +40,124 @@ const ProfileIcon = ({ iconSize, labelClasses, classes }) => {
   )
 }
 
-class LoginComponent extends Component {
-  static propTypes = LoginPropTypes
+const defaultShowIconProfile = { "desktop": false, "mobile": true }
 
-  /** Function called after login success */
-  onClickLoginButton = () => {
-    window.location.reload()
-  }
+const LoginIcon = ({
+  iconSize,
+  iconLabel: iconLabelProfile,
+  labelClasses,
+  loginButtonAsLink,
+  onProfileIconClick,
+  sessionProfile,
+  showIconProfile = defaultShowIconProfile,
+}) => {
+  const { history, navigate } = useRuntime()
+  const { formatMessage } = useIntl()
+  const iconProfile = useResponsiveValue(showIconProfile)
 
-  renderIcon = () => {
-    const {
-      iconSize,
-      iconLabel: iconLabelProfile,
-      labelClasses,
-      intl,
-      loginButtonAsLink,
-      onProfileIconClick,
-      sessionProfile,
-      showIconProfile,
-      runtime: { history, navigate },
-    } = this.props
+  const pathname = history && history.location && history.location.pathname
 
-    const pathname = history && history.location && history.location.pathname
-
-    const iconClasses = 'flex items-center'
-    const iconLabel = iconLabelProfile || translate('store/login.signIn', intl)
-    const buttonContent = (
-      <Fragment>
-        {sessionProfile ? (
+  const iconClasses = 'flex items-center'
+  const iconLabel = iconLabelProfile || formatMessage({ id: 'store/login.signIn' })
+  const buttonContent = (
+    <Fragment>
+      {sessionProfile ? (
+        <span
+          className={`${styles.profile} t-action--small order-1 ${iconProfile ? 'pl4' : ''} ${labelClasses} dn db-l`}
+        >
+          {formatMessage({ id: 'store/login.hello' })}{' '}
+          {sessionProfile.firstName || truncateString(sessionProfile.email)}
+        </span>
+      ) : (
+        iconLabel && (
           <span
-            className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}
+            className={`${styles.label} t-action--small ${iconProfile ? 'pl4 dn db-l' : ''} ${labelClasses}`}
           >
-            {translate('store/login.hello', intl)}{' '}
-            {sessionProfile.firstName || truncateString(sessionProfile.email)}
+            {iconLabel}
           </span>
-        ) : (
-          iconLabel && (
-            <span
-              className={`${styles.label} t-action--small pl4 ${labelClasses} dn db-l`}
-            >
-              {iconLabel}
-            </span>
-          )
-        )}
-      </Fragment>
-    )
+        )
+      )}
+    </Fragment>
+  )
 
-    if (loginButtonAsLink) {
-      const linkTo = sessionProfile ? 'store.account' : 'store.login'
-      const returnUrl =
-        !sessionProfile && `returnUrl=${encodeURIComponent(pathname)}`
-      return (
-        <div className={styles.buttonLink}>
-          <ButtonWithIcon
-            variation="tertiary"
-            icon={
-              showIconProfile && (
-                <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} iconClasses={iconClasses} />
-              )
-            }
-            iconPosition={showIconProfile ? 'left' : 'right'}
-            onClick={() => navigate({ page: linkTo, query: returnUrl })}
-          >
-            {buttonContent}
-          </ButtonWithIcon>
-        </div>
-      )
-    }
-
+  if (loginButtonAsLink) {
+    const linkTo = sessionProfile ? 'store.account' : 'store.login'
+    const returnUrl =
+      !sessionProfile && `returnUrl=${encodeURIComponent(pathname)}`
     return (
-      <ButtonWithIcon
-        variation="tertiary"
-        icon={
-          showIconProfile && (
-            <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} />
-          )
-        }
-        iconPosition={showIconProfile ? 'left' : 'right'}
-        onClick={onProfileIconClick}
-      >
-        <div
-          className="flex pv2 items-center"
-          ref={e => {
-            this.iconRef = e
-          }}
+      <div className={styles.buttonLink}>
+        <ButtonWithIcon
+          variation="tertiary"
+          icon={
+            iconProfile && (
+              <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} iconClasses={iconClasses} />
+            )
+          }
+          iconPosition={iconProfile ? 'left' : 'right'}
+          onClick={() => navigate({ page: linkTo, query: returnUrl })}
         >
           {buttonContent}
-        </div>
-      </ButtonWithIcon>
-    )
-  }
-
-  render() {
-    const {
-      isBoxOpen,
-      onOutSideBoxClick,
-      sessionProfile,
-      mirrorTooltipToRight,
-    } = this.props
-
-    return (
-      <div className={`${styles.container} flex items-center fr`}>
-        <div className="relative">
-          {this.renderIcon()}
-          {isBoxOpen && (
-            <Overlay>
-              <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
-                <Popover mirrorTooltipToRight={mirrorTooltipToRight}>
-                  <Suspense fallback={<Loading />}>
-                    <LoginContent
-                      profile={sessionProfile}
-                      loginCallback={this.onClickLoginButton}
-                      isInitialScreenOptionOnly
-                      {...this.props}
-                    />
-                  </Suspense>
-                </Popover>
-              </OutsideClickHandler>
-            </Overlay>
-          )}
-        </div>
+        </ButtonWithIcon>
       </div>
     )
   }
+
+  return (
+    <ButtonWithIcon
+      variation="tertiary"
+      icon={
+        iconProfile && (
+          <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} />
+        )
+      }
+      iconPosition={iconProfile ? 'left' : 'right'}
+      onClick={onProfileIconClick}
+    >
+      <div className="flex pv2 items-center">
+        {buttonContent}
+      </div>
+    </ButtonWithIcon>
+  )
 }
 
-export default withRuntimeContext(LoginComponent)
+/** Function called after login success */
+const handleClickLoginButton = () => {
+  window.location.reload()
+}
+
+const LoginComponent = (props) => {
+  const {
+    isBoxOpen,
+    onOutSideBoxClick,
+    sessionProfile,
+    mirrorTooltipToRight,
+  } = props
+
+  return (
+    <div className={`${styles.container} flex items-center fr`}>
+      <div className="relative">
+        <LoginIcon {...props} />
+        {isBoxOpen && (
+          <Overlay>
+            <OutsideClickHandler onOutsideClick={onOutSideBoxClick}>
+              <Popover mirrorTooltipToRight={mirrorTooltipToRight}>
+                <Suspense fallback={<Loading />}>
+                  <LoginContent
+                    profile={sessionProfile}
+                    loginCallback={handleClickLoginButton}
+                    isInitialScreenOptionOnly
+                    {...props}
+                  />
+                </Suspense>
+              </Popover>
+            </OutsideClickHandler>
+          </Overlay>
+        )}
+      </div>
+    </div>
+  )
+}
+
+LoginComponent.propTypes = LoginPropTypes
+
+export default LoginComponent

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -11,6 +11,7 @@ import { IconProfile } from 'vtex.store-icons'
 import Overlay from 'vtex.react-portal/Overlay'
 import { ButtonWithIcon } from 'vtex.styleguide'
 import { useResponsiveValue } from 'vtex.responsive-values'
+import { useDevice } from 'vtex.device-detector'
 
 import { truncateString } from '../utils/format-string'
 import { LoginPropTypes } from '../propTypes'
@@ -54,6 +55,7 @@ const LoginIcon = ({
   const { history, navigate } = useRuntime()
   const { formatMessage } = useIntl()
   const iconProfile = useResponsiveValue(showIconProfile)
+  const { isMobile } = useDevice()
 
   const pathname = history && history.location && history.location.pathname
 
@@ -63,7 +65,7 @@ const LoginIcon = ({
     <Fragment>
       {sessionProfile ? (
         <span
-          className={`${styles.profile} t-action--small order-1 ${iconProfile ? 'pl4' : ''} ${labelClasses} dn db-l`}
+          className={`${styles.profile} t-action--small order-1 ${iconProfile ? 'pl4' : ''} ${labelClasses}`}
         >
           {formatMessage({ id: 'store/login.hello' })}{' '}
           {sessionProfile.firstName || truncateString(sessionProfile.email)}
@@ -71,7 +73,7 @@ const LoginIcon = ({
       ) : (
         iconLabel && (
           <span
-            className={`${styles.label} t-action--small ${iconProfile ? 'pl4 dn db-l' : ''} ${labelClasses}`}
+            className={`${styles.label} t-action--small ${iconProfile ? 'pl4' : ''} ${labelClasses}`}
           >
             {iconLabel}
           </span>
@@ -96,7 +98,7 @@ const LoginIcon = ({
           iconPosition={iconProfile ? 'left' : 'right'}
           onClick={() => navigate({ page: linkTo, query: returnUrl })}
         >
-          {buttonContent}
+          {!isMobile && buttonContent}
         </ButtonWithIcon>
       </div>
     )
@@ -113,9 +115,9 @@ const LoginIcon = ({
       iconPosition={iconProfile ? 'left' : 'right'}
       onClick={onProfileIconClick}
     >
-      <div className="flex pv2 items-center">
+      {!isMobile && <div className="flex pv2 items-center">
         {buttonContent}
-      </div>
+      </div>}
     </ButtonWithIcon>
   )
 }

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -23,7 +23,15 @@ export const LoginContainerProptypes = {
   /** Label's classnames */
   labelClasses: PropTypes.string,
   /** Determines if the icon profile will be hidden */
-  showIconProfile: PropTypes.bool,
+  showIconProfile: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      mobile: PropTypes.bool,
+      desktop: PropTypes.bool,
+      tablet: PropTypes.bool,
+      phone: PropTypes.bool
+    })
+  ]),
   /** Password login button text */
   providerPasswordButtonLabel: PropTypes.string,
   /** Whether the identifier extension values are enabled in the site editor */


### PR DESCRIPTION
#### What problem is this solving?

If you open https://storetheme.vtex.com/ on mobile you can see that the login component is not visible:
![image](https://user-images.githubusercontent.com/284515/76012500-2640c980-5ef5-11ea-8d12-98007b6e2688.png)

That happens because the label it's hidden when it's mobile and the `showIconProfile` default value is `undefined`.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

Also tested on:
- alssports
- boticario
- tacktoftheday
- samsungar
- motorolaus
- paguemenos
- ecowaterqa (improved alignment on mobile)
- babycottonsar
- biscoind (improved alignment on mobile)
- redoxx (small change https://breno--redoxx.myvtex.com/)
- umbro
- admitone
- gympassbr. Need to fix the CSS:

<table>
<thead>
<tr>
<td>Before</td><td>After</td>
</tr>
</thead>
<tbody>
<tr>
<td>

```css
.vtex-login-2-x-container button {
    background: url(https://gympassus.vteximg.com.br/arquivos/ids/155411) no-repeat 6px center;
}
```

</td>
<td>

```css
.vtex-login-2-x-container button {
    background: url(https://gympassus.vteximg.com.br/arquivos/ids/155411) no-repeat -1px center;
}
```

</td>
</tbody>
</table>
- hushpuppiescl. Need to fix mobile CSS:


<table>
<tr><td>Add</td><td>Remove</td></tr>
<tr><td>

```css
/* vtex.login.css */
.container :global(.vtex-button__label) {
    background: url(/arquivos/user-2.png) no-repeat;
    height: 23px;
    background-size: contain;
    margin-left: 1em;
    margin-bottom: 1px;
    margin-right: 1px;
}
```

</td><td>

CSS defintions that have the selectors:
- `.container .label:before, .profile:before`
- `.container .label:after, .profile:before`

</td></table>

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
