### PR TITLE
Feature/account link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `accountOptionsButtonBehavior` prop to the `login` interface. It defaults to `popover` and can be changed to `link`
+
+- New `accountOptionsButtonBehavior` prop to the site-editor
+
 ## [2.25.0] - 2020-03-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `accountOptionsButtonBehavior` prop to the `login` interface. It defaults to `popover` and can be changed to `link`
-
 - New `accountOptionsButtonBehavior` prop to the site-editor
 
 ## [2.25.0] - 2020-03-10

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,26 +94,27 @@ For now these blocks do not have any required or optional blocks.
 
 Through the Storefront, you can change the `login`'s behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name                                          | Type      | Description                                                                                   | Default value |
-| -------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
-| `optionsTitle`                                     | `String`  | Set title of login options                                                                    | -             |
-| `emailAndPasswordTitle`                            | `String`  | Set title of login with email and password                                                    | -             |
-| `accessCodeTitle`                                  | `String`  | Set title of login by access code                                                             | -             |
-| `emailPlaceholder`                                 | `String`  | Set placeholder to email input                                                                | -             |
-| `passwordPlaceholder`                              | `String`  | Set placeholder to password input                                                             | -             |
-| `showPasswordVerificationIntoTooltip`              | `Boolean` | Set show password format verification as tooltip                                              | -             |
-| `acessCodePlaceholder`                             | `String`  | Set placeholder to access code input                                                          | -             |
-| `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                    | -             |
-| `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                                  | -             |
-| `iconLabel`                                        | `String`  | Set label of the login button                                                                 | -             |
-| `labelClasses`                                     | `String`  | Label's classnames                                                                            | -             |
-| `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                                | -             |
-| `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                   | -             |
-| `identifierPlaceholder`                            | `String`  | Set placeholder for the identifier extension                                                  | -             |
-| `invalidIdentifierError`                           | `String`  | Set error message for invalid user identifier                                                 | -             |
-| `mirrorTooltipToRight`                             | `Boolean` | Makes login tooltip open towards the right side                                               | -             |
-| `logInButtonBehavior`                              | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page | "popover"     |
-| `accountOptionLinks`                               | `Array`   | Determines more specific account option links to replace the `My Account` link.<br>Each array element is an object with the properties:<br><ul><li>`label` [`string`] - Link text</li><li>`path` [`string`] - Relative path to where the link leads</li><li>`cssClass` [`string`] - CSS class the link receives</li></ul> | -             |
+| Prop name                                          | Type      | Description                                                                                              | Default value |
+| -------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------- | ------------- |
+| `optionsTitle`                                     | `String`  | Set title of login options                                                                               | -             |
+| `emailAndPasswordTitle`                            | `String`  | Set title of login with email and password                                                               | -             |
+| `accessCodeTitle`                                  | `String`  | Set title of login by access code                                                                        | -             |
+| `emailPlaceholder`                                 | `String`  | Set placeholder to email input                                                                           | -             |
+| `passwordPlaceholder`                              | `String`  | Set placeholder to password input                                                                        | -             |
+| `showPasswordVerificationIntoTooltip`              | `Boolean` | Set show password format verification as tooltip                                                         | -             |
+| `acessCodePlaceholder`                             | `String`  | Set placeholder to access code input                                                                     | -             |
+| `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                               | -             |
+| `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                                             | -             |
+| `iconLabel`                                        | `String`  | Set label of the login button                                                                            | -             |
+| `labelClasses`                                     | `String`  | Label's classnames                                                                                       | -             |
+| `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                                           | -             |
+| `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                              | -             |
+| `identifierPlaceholder`                            | `String`  | Set placeholder for the identifier extension                                                             | -             |
+| `invalidIdentifierError`                           | `String`  | Set error message for invalid user identifier                                                            | -             |
+| `mirrorTooltipToRight`                             | `Boolean` | Makes login tooltip open towards the right side                                                          | -             |
+| `logInButtonBehavior`                              | `Enum`    | Set log in button behavior. `"popover"` for popover, `"link"` for a link to the `/login` page            | "popover"     |
+| `accountOptionsButtonBehavior`                     | `Enum`    | Set account options button behavior. `"popover"` for popover, `"link"` for a link to the `/account` page | "popover"     |
+| `accountOptionLinks`                               | `Array`   | Determines more specific account option links to replace the `My Account` link.<br>Each array element is an object with the properties:<br><ul><li>`label` [`string`] - Link text</li><li>`path` [`string`] - Relative path to where the link leads</li><li>`cssClass` [`string`] - CSS class the link receives</li></ul>                           | -             |
 
 You can also change the `login-content`'s behaviour and interface through the Store front.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.25.0",
+  "version": "2.26.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/context.json
+++ b/messages/context.json
@@ -54,6 +54,7 @@
   "admin/editor.login.invalidIdentifierError": "admin/editor.login.invalidIdentifierError",
   "admin/editor.login.mirrorTooltipToRightTitle": "admin/editor.login.mirrorTooltipToRightTitle",
   "admin/editor.login.logInButtonBehavior": "admin/editor.login.logInButtonBehavior",
+  "admin/editor.login.accountOptionsButtonBehavior": "admin/editor.login.accountOptionsButtonBehavior",
   "admin/editor.login.accountOptionLinks": "admin/editor.login.accountOptionLinks",
   "admin/editor.login.accountOptionLabelTitle": "admin/editor.login.accountOptionLabelTitle",
   "admin/editor.login.accountOptionPathTitle": "admin/editor.login.accountOptionPathTitle",

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,8 +54,9 @@
   "admin/editor.login.invalidIdentifierError": "Invalid identifier error",
   "admin/editor.login.mirrorTooltipToRightTitle": "Mirror tooltip to right",
   "admin/editor.login.logInButtonBehavior": "Log in button behavior",
-  "admin/editor.login.accountOptionLinks": "Account Option Links",
+  "admin/editor.login.accountOptionsButtonBehavior": "Account options button behavior",
+  "admin/editor.login.accountOptionLinks": "Account option links",
   "admin/editor.login.accountOptionLabelTitle": "Label",
   "admin/editor.login.accountOptionPathTitle": "Path",
-  "admin/editor.login.accountOptionCssClassTitle": "CSS Class"
+  "admin/editor.login.accountOptionCssClassTitle": "CSS class"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -54,7 +54,8 @@
   "admin/editor.login.invalidIdentifierError": "Error de identificador inválido",
   "admin/editor.login.mirrorTooltipToRightTitle": "Reflejar tooltip a la derecha",
   "admin/editor.login.logInButtonBehavior": "Comportamiento del botón de login",
-  "admin/editor.login.accountOptionLinks": "Enlaces de Opción de la Cuenta",
+  "admin/editor.login.accountOptionsButtonBehavior": "Comportamiento del botón de opciones de la cuenta",
+  "admin/editor.login.accountOptionLinks": "Enlaces de opción de la cuenta",
   "admin/editor.login.accountOptionLabelTitle": "Label",
   "admin/editor.login.accountOptionPathTitle": "Path",
   "admin/editor.login.accountOptionCssClassTitle": "Clase CSS"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -54,7 +54,8 @@
   "admin/editor.login.invalidIdentifierError": "Erro de identificador inválido",
   "admin/editor.login.mirrorTooltipToRightTitle": "Espelhar tooltip para a direita",
   "admin/editor.login.logInButtonBehavior": "Comportamento do botão de login",
-  "admin/editor.login.accountOptionLinks": "Links de Opção da Conta",
+  "admin/editor.login.accountOptionsButtonBehavior": "Comportamento do botão de opções da conta",
+  "admin/editor.login.accountOptionLinks": "Links de opção da conta",
   "admin/editor.login.accountOptionLabelTitle": "Label",
   "admin/editor.login.accountOptionPathTitle": "Path",
   "admin/editor.login.accountOptionCssClassTitle": "Classe CSS"

--- a/react/Login.js
+++ b/react/Login.js
@@ -82,7 +82,9 @@ export default class Login extends Component {
   render() {
     const { logInButtonBehavior, accountOptionsButtonBehavior } = this.props
     const { sessionProfile } = this.state
-    const shouldBeLink = this.state.isMobileScreen || (sessionProfile ? accountOptionsButtonBehavior === ButtonBehavior.LINK : logInButtonBehavior === ButtonBehavior.LINK)
+    const {isMobileScreen} = this.state
+    const buttonLink = ButtonBehavior.LINK
+    const shouldBeLink = isMobileScreen || (sessionProfile ? accountOptionsButtonBehavior === buttonLink : logInButtonBehavior === buttonLink)
     
     return (
       <LoginWithSession

--- a/react/Login.js
+++ b/react/Login.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { withSession } from 'vtex.render-runtime'
 import { injectIntl } from 'react-intl'
 
-import { LogInButtonBehavior } from './common/global'
+import { ButtonBehavior } from './common/global'
 import { LoginSchema } from './schema'
 import { setCookie } from './utils/set-cookie'
 import { LoginContainerProptypes } from './propTypes'
@@ -19,7 +19,7 @@ export default class Login extends Component {
 
   static defaultProps = {
     labelClasses: DEFAULT_CLASSES,
-    logInButtonBehavior: LogInButtonBehavior.POPOVER,
+    logInButtonBehavior: ButtonBehavior.POPOVER,
   }
 
   state = {
@@ -80,14 +80,15 @@ export default class Login extends Component {
   }
 
   render() {
-    const { logInButtonBehavior } = this.props
-    const shouldBeLink = this.state.isMobileScreen || logInButtonBehavior === LogInButtonBehavior.LINK
-
+    const { logInButtonBehavior, accountOptionsButtonBehavior } = this.props
+    const { sessionProfile } = this.state
+    const shouldBeLink = this.state.isMobileScreen || (sessionProfile ? accountOptionsButtonBehavior === ButtonBehavior.LINK : logInButtonBehavior === ButtonBehavior.LINK)
+    
     return (
       <LoginWithSession
         isBoxOpen={this.state.isBoxOpen}
         loginButtonAsLink={shouldBeLink}
-        sessionProfile={this.state.sessionProfile}
+        sessionProfile={sessionProfile}
         {...this.props}
         onOutSideBoxClick={this.handleOutSideBoxClick}
         onProfileIconClick={this.handleProfileIconClick}
@@ -109,8 +110,8 @@ Login.getSchema = () => ({
     logInButtonBehavior: {
       title: 'admin/editor.login.logInButtonBehavior',
       type: 'string',
-      enum: [LogInButtonBehavior.POPOVER, LogInButtonBehavior.LINK],
-      default: LogInButtonBehavior.POPOVER,
+      enum: [ButtonBehavior.POPOVER, ButtonBehavior.LINK],
+      default: ButtonBehavior.POPOVER,
     },
     accountOptionLinks: {
       title: 'admin/editor.login.accountOptionLinks',

--- a/react/Login.js
+++ b/react/Login.js
@@ -81,8 +81,7 @@ export default class Login extends Component {
 
   render() {
     const { logInButtonBehavior, accountOptionsButtonBehavior } = this.props
-    const { sessionProfile } = this.state
-    const {isMobileScreen} = this.state
+    const { sessionProfile, isMobileScreen } = this.state
     const buttonLink = ButtonBehavior.LINK
     const shouldBeLink = isMobileScreen || (sessionProfile ? accountOptionsButtonBehavior === buttonLink : logInButtonBehavior === buttonLink)
     

--- a/react/Login.js
+++ b/react/Login.js
@@ -113,6 +113,12 @@ Login.getSchema = () => ({
       enum: [ButtonBehavior.POPOVER, ButtonBehavior.LINK],
       default: ButtonBehavior.POPOVER,
     },
+    accountOptionsButtonBehavior: {
+      title: 'admin/editor.login.accountOptionsButtonBehavior',
+      type: 'string',
+      enum: [ButtonBehavior.POPOVER, ButtonBehavior.LINK],
+      default: ButtonBehavior.POPOVER,
+    },
     accountOptionLinks: {
       title: 'admin/editor.login.accountOptionLinks',
       type: 'array',

--- a/react/common/global.js
+++ b/react/common/global.js
@@ -1,6 +1,7 @@
 export const USER_IDENTIFIER_INTERFACE_ID = 'user-identifier'
-export const SELF_APP_NAME_AND_VERSION = process.env.VTEX_APP_ID || process.env.VTEX_APP_NAME || null
-export const LogInButtonBehavior = {
+export const SELF_APP_NAME_AND_VERSION =
+  process.env.VTEX_APP_ID || process.env.VTEX_APP_NAME || null
+export const ButtonBehavior = {
   POPOVER: 'popover',
   LINK: 'link',
 }

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -36,6 +36,8 @@ export const LoginContainerProptypes = {
   mirrorTooltipToRight: PropTypes.bool,
   /** Determines what happens when the log in button is pressed */
   logInButtonBehavior: PropTypes.string,
+  /** Determines what happens when the account options button is pressed (the user is logged in) */
+  accountOptionsButtonBehavior: PropTypes.string,
   /** Determines more specific account option buttons to replace the "My Account" button */
   accountOptionLinks: PropTypes.array,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a prop to change the account options button behavior (make it open a popup or act as a link)

#### What problem is this solving?
It adds the prop `accountOptionsButtonBehavior`, that defaults to `popover` and can be changed to `link`. It also adds that prop to the site-editor.

#### How should this be manually tested?

Go into
https://rafaprtest--storecomponents.myvtex.com/admin/cms/site-editor
and log in using the button in the store header. Click the account options button (the `Hello, {{name}}` button) and you'll see a popover opens. Then, click `Login` in the right sidebar and scroll to the `Account options button behavior` field. Change it from "popover" to "link". Then, if you click the account options button again, you should be directly redirected to the `/account` page.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/76359827-9044de80-62fa-11ea-80cc-f8d1d61011e0.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Clubhouse hooks
[ch32858]