### PR TITLE
Keep __bindingAddress query string when redirecting after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Keep `__bindingAddress` query string when redirecting after login.
 
 ## [2.28.0] - 2020-03-18
 
@@ -208,7 +211,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make password verification fixed after it was shown
 
 ## [2.13.1] - 2019-05-23
-### Fixed 
+### Fixed
 - Page reload after login for price update
 
 ## [2.13.0] - 2019-05-17

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -172,8 +172,18 @@ class LoginContent extends Component {
         },
       },
     } = this.props
-    const currentUrl = page !== 'store.login' ? `${pathname}${search}` : '/'
-    return path(['query', 'returnUrl'], this.props) || currentUrl
+    const fromQuery = path(['query', 'returnUrl'], this.props)
+    if (fromQuery) {
+      return fromQuery
+    }
+
+    if (page !== 'store.login') {
+      return `${pathname}${search}`
+    }
+
+    return search.includes('__bindingAddress')
+      ? `/${search}`
+      : '/'
   }
 
   componentDidMount() {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Closes https://github.com/vtex-apps/login/issues/178

#### What problem is this solving?
For details, please refer to https://github.com/vtex-apps/login/issues/178

#### How should this be manually tested?
You can see it working here: https://keepbinding--powerplanet.myvtex.com/login?__bindingAddress=www.powerplanetonline.com/pt

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
