### PR TITLE
Fix/broken dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `react-device-detect` dependency removed to fix broken SSR
+- Password tooltip opening direction depended on device type rather than screen size
 
 ## [2.29.0] - 2020-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `react-device-detect` dependency removed to fix broken SSR
+
 ## [2.29.0] - 2020-04-08
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.29.0",
+  "version": "2.29.1-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/TooltipVerification.js
+++ b/react/components/TooltipVerification.js
@@ -1,17 +1,21 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
-import { isMobile } from 'react-device-detect'
+
 import { translate } from '../utils/translate'
 import Tooltip from './Tooltip'
 import PasswordValidationContent from './PasswordValidationContent'
+import getIsMobile from '../utils/getIsMobile'
 
 class TooltipVerification extends Component {
   render() {
     const { fields, intl } = this.props
-    if (isMobile) {
+    if (getIsMobile()) {
       return (
-        <Tooltip top title={translate('store/login.password.tooltip.title', intl)}>
+        <Tooltip
+          top
+          title={translate('store/login.password.tooltip.title', intl)}
+        >
           <PasswordValidationContent fields={fields} />
         </Tooltip>
       )
@@ -28,7 +32,7 @@ class TooltipVerification extends Component {
 TooltipVerification.propTypes = {
   /** Fields to be verified in the tooltip */
   fields: PropTypes.array,
-  /** Intl object*/
+  /** Intl object */
   intl: intlShape,
 }
 

--- a/react/package.json
+++ b/react/package.json
@@ -14,7 +14,6 @@
     "ramda": "^0.24.1",
     "react": "^16.3.2",
     "react-apollo": "~2.1.3",
-    "react-device-detect": "^1.5.8",
     "react-intl": "3.9.1",
     "react-markdown": "^4.3.1",
     "slugify": "^1.3.1"

--- a/react/utils/getIsMobile.js
+++ b/react/utils/getIsMobile.js
@@ -1,5 +1,9 @@
 const getIsMobile = () => {
-  return window.matchMedia('(max-width: 40em)').matches
+  return (
+    window &&
+    window.matchMedia &&
+    window.matchMedia('(max-width: 40em)').matches
+  )
 }
 
 export default getIsMobile

--- a/react/utils/getIsMobile.js
+++ b/react/utils/getIsMobile.js
@@ -1,0 +1,5 @@
+const getIsMobile = () => {
+  return window.matchMedia('(max-width: 40em)').matches
+}
+
+export default getIsMobile

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5018,13 +5018,6 @@ react-apollo@~2.1.3:
     lodash "^4.17.10"
     prop-types "^15.6.0"
 
-react-device-detect@^1.5.8:
-  version "1.11.14"
-  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.11.14.tgz#02ba2398e2ce81fb0eaed3e62a9ad713ab3870a7"
-  integrity sha512-WSjch241xI+rXHVtJaSYxNUT2WAykzfJgMI2Hg9xjNNTlIZdJu/fmWf4iedNH7qzFq+JaJ6fDJu3mrKFLerKBw==
-  dependencies:
-    ua-parser-js "^0.7.20"
-
 react-dom@^16.8.3, react-dom@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -5979,7 +5972,7 @@ typescript@3.8.3, typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
-ua-parser-js@^0.7.18, ua-parser-js@^0.7.20:
+ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove `react-device-detect` dependency, because it's breaking SSR

#### How should this be manually tested?

Go to
https://rafarubim--storecomponents.myvtex.com/login
The lib was only being used to determine the password tooltip opening direction in mobile. It only depends on screen size now (as it should).

#### Screenshots or example usage

**Desktop**
![image](https://user-images.githubusercontent.com/22064061/78934925-2dbe3a00-7a82-11ea-82c3-f04c6fcf9fcc.png)

**Mobile**
![image](https://user-images.githubusercontent.com/22064061/78935029-5ba37e80-7a82-11ea-9cf5-ee98b83a458d.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Clubhouse hooks

[ch35511]