### PR TITLE
Uses react-vtexid service hook for redirect

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.30.0",
+  "version": "2.30.1-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -147,6 +147,7 @@ class LoginContent extends Component {
     termsAndConditions: PropTypes.string,
     returnUrl: PropTypes.string,
     defaultIsCreatePassword: PropTypes.bool,
+    redirectAfterLogin: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -253,16 +254,7 @@ class LoginContent extends Component {
       if (loginCallback) {
         loginCallback()
       } else {
-        // the use of location.assign here, instead of
-        // the redirect method, is because on CSR the
-        // components using authentication and relying
-        // on the session cookie haven't been updated yet,
-        // so the refresh is intentional.
-        location.assign(
-          `/api/vtexid/pub/authentication/redirect?returnUrl=${encodeURIComponent(
-            this.props.returnUrl
-          )}`
-        )
+        this.props.redirectAfterLogin()
       }
     })
   }
@@ -419,6 +411,8 @@ const LoginContentWrapper = props => {
       email: userEmail,
     },
   })
+  
+  const [redirectAfterLogin] = serviceHooks.useRedirectAfterLogin()
 
   if (isCreatePassFlow && (!userEmail || errorSendAccessKey)) {
     return (
@@ -426,6 +420,7 @@ const LoginContentWrapper = props => {
         {...props}
         defaultOption={steps.EMAIL_VERIFICATION}
         defaultIsCreatePassword
+        redirectAfterLogin={redirectAfterLogin}
       />
     )
   }
@@ -437,7 +432,13 @@ const LoginContentWrapper = props => {
       </div>
     )
   }
-  return <LoginContent {...props} defaultOption={defaultOption} />
+  return (
+    <LoginContent
+      {...props}
+      defaultOption={defaultOption}
+      redirectAfterLogin={redirectAfterLogin}
+    />
+  )
 }
 
 const LoginContentProvider = props => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Updates the app to use the RedirectAfterLogin (service hook) exported by `react-vtexid`.

#### What problem is this solving?
Login app was not using the RedirectAfterLogin feature from `react-vtexid` and, because of that, was not using the rootPath to build the URL. 

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
