### PR TITLE
Feature/binding redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- When the header behavior is LINK, it passes `__bindingAddress` in navigation
+- When the header behavior is LINK, it adds the current query string to the `returnUrl`
+
+### Changed
+
+- When `returnUrl` doesn't exist, redirect to default url defined by `vtex.react-vtexid` or consider `rootPath` and `__bindingAddress`
+
 ## [2.32.0] - 2020-05-21
 ### Added
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.32.0",
+  "version": "2.33.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/common/global.js
+++ b/react/common/global.js
@@ -9,8 +9,4 @@ export const GoogleOneTapAlignment = {
   RIGHT: 'Right',
   LEFT: 'Left',
 }
-export const ROOT_PATH =
-  (window && window.__RUNTIME__ && window.__RUNTIME__.rootPath) || ''
-const search = window && window.location && window.location.search
-const searchParams = new URLSearchParams(search)
-export const BINDING_ADDRESS = searchParams.get('__bindingAddress')
+export const ROOT_PATH = (__RUNTIME__ && __RUNTIME__.rootPath) || ''

--- a/react/common/global.js
+++ b/react/common/global.js
@@ -9,6 +9,8 @@ export const GoogleOneTapAlignment = {
   RIGHT: 'Right',
   LEFT: 'Left',
 }
+export const ROOT_PATH =
+  (window && window.__RUNTIME__ && window.__RUNTIME__.rootPath) || ''
 const search = window && window.location && window.location.search
 const searchParams = new URLSearchParams(search)
 export const BINDING_ADDRESS = searchParams.get('__bindingAddress')

--- a/react/common/global.js
+++ b/react/common/global.js
@@ -9,3 +9,6 @@ export const GoogleOneTapAlignment = {
   RIGHT: 'Right',
   LEFT: 'Left',
 }
+const search = window && window.location && window.location.search
+const searchParams = new URLSearchParams(search)
+export const BINDING_ADDRESS = searchParams.get('__bindingAddress')

--- a/react/components/AccountOptions.js
+++ b/react/components/AccountOptions.js
@@ -60,7 +60,7 @@ const AccountOptions = ({ intl, optionLinks }) => {
       </div>
       <hr className="mv2 o-30" />
       <div className="mv4 min-h-2 b--muted-4">
-        <AuthServiceLazy.RedirectLogout returnUrl="/">
+        <AuthServiceLazy.RedirectLogout>
           {({ action: logout }) => {
             if (hasOptionLinks) {
               return (

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -58,6 +58,7 @@ class LoginComponent extends Component {
     } = this.props
 
     const pathname = history && history.location && history.location.pathname
+    const search = history && history.location && history.location.search
 
     const iconClasses = 'flex items-center'
     const iconLabel = iconLabelProfile || translate('store/login.signIn', intl)
@@ -85,7 +86,7 @@ class LoginComponent extends Component {
     if (loginButtonAsLink) {
       const linkTo = sessionProfile ? 'store.account' : 'store.login'
       const returnUrl =
-        !sessionProfile && `returnUrl=${encodeURIComponent(pathname)}`
+        !sessionProfile && `returnUrl=${encodeURIComponent(`${pathname}${search}`)}`
       return (
         <div className={styles.buttonLink}>
           <ButtonWithIcon

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -15,7 +15,6 @@ import { truncateString } from '../utils/format-string'
 import { translate } from '../utils/translate'
 import { LoginPropTypes } from '../propTypes'
 import OneTapSignin from './OneTapSignin'
-import composeQueryString from '../utils/composeQueryString'
 import getBindingAddress from '../utils/getBindingAddress'
 
 import styles from '../styles.css'
@@ -102,12 +101,12 @@ class LoginComponent extends Component {
             iconPosition={showIconProfile ? 'left' : 'right'}
             onClick={() => navigate({
               page: linkTo,
-              query: composeQueryString({
+              query: new URLSearchParams({
                 returnUrl,
                 ...(bindingAddress && {
                   bindingAddress,
                 }),
-              })
+              }).toString()
             })}
           >
             {buttonContent}

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -15,6 +15,8 @@ import { truncateString } from '../utils/format-string'
 import { translate } from '../utils/translate'
 import { LoginPropTypes } from '../propTypes'
 import OneTapSignin from './OneTapSignin'
+import composeQueryString from '../utils/composeQueryString'
+import { BINDING_ADDRESS } from '../common/global'
 
 import styles from '../styles.css'
 import Loading from './Loading'
@@ -97,7 +99,15 @@ class LoginComponent extends Component {
               )
             }
             iconPosition={showIconProfile ? 'left' : 'right'}
-            onClick={() => navigate({ page: linkTo, query: returnUrl })}
+            onClick={() => navigate({
+              page: linkTo,
+              query: composeQueryString({
+                returnUrl,
+                ...(BINDING_ADDRESS && {
+                  BINDING_ADDRESS,
+                }),
+              })
+            })}
           >
             {buttonContent}
           </ButtonWithIcon>

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -16,7 +16,7 @@ import { translate } from '../utils/translate'
 import { LoginPropTypes } from '../propTypes'
 import OneTapSignin from './OneTapSignin'
 import composeQueryString from '../utils/composeQueryString'
-import { BINDING_ADDRESS } from '../common/global'
+import getBindingAddress from '../utils/getBindingAddress'
 
 import styles from '../styles.css'
 import Loading from './Loading'
@@ -89,6 +89,7 @@ class LoginComponent extends Component {
       const linkTo = sessionProfile ? 'store.account' : 'store.login'
       const returnUrl =
         !sessionProfile && `returnUrl=${encodeURIComponent(`${pathname}${search}`)}`
+      const bindingAddress = getBindingAddress()
       return (
         <div className={styles.buttonLink}>
           <ButtonWithIcon
@@ -103,8 +104,8 @@ class LoginComponent extends Component {
               page: linkTo,
               query: composeQueryString({
                 returnUrl,
-                ...(BINDING_ADDRESS && {
-                  BINDING_ADDRESS,
+                ...(bindingAddress && {
+                  bindingAddress,
                 }),
               })
             })}

--- a/react/utils/composeQueryString.js
+++ b/react/utils/composeQueryString.js
@@ -1,0 +1,7 @@
+const composeQueryString = queryObj => {
+  return Object.keys(queryObj)
+    .map(key => `${key}=${encodeURIComponent(queryObj[key] || '')}`)
+    .join('&')
+}
+
+export default composeQueryString

--- a/react/utils/composeQueryString.js
+++ b/react/utils/composeQueryString.js
@@ -1,7 +1,0 @@
-const composeQueryString = queryObj => {
-  return Object.keys(queryObj)
-    .map(key => `${key}=${encodeURIComponent(queryObj[key] || '')}`)
-    .join('&')
-}
-
-export default composeQueryString

--- a/react/utils/getBindingAddress.js
+++ b/react/utils/getBindingAddress.js
@@ -1,0 +1,7 @@
+const getBindingAddress = () => {
+  const search = window && window.location && window.location.search
+  const searchParams = new URLSearchParams(search)
+  return searchParams.get('__bindingAddress')
+}
+
+export default getBindingAddress

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -22,9 +22,10 @@ export const jsRedirect = ({ runtime, isHeaderLogin }) => {
   const url = getReturnUrl() || getDefaultRedirectUrl(isHeaderLogin)
 
   if (!url) {
-    const queryString = new URLSearchParams({
-      __bindingAddress: getBindingAddress(),
-    }).toString()
+    const __bindingAddress = getBindingAddress()
+    const queryString = __bindingAddress
+      ? new URLSearchParams({ __bindingAddress }).toString()
+      : ''
     return `${ROOT_PATH}/?${queryString}`
   }
 

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -1,3 +1,6 @@
+import { BINDING_ADDRESS, ROOT_PATH } from '../common/global'
+import composeQueryString from './composeQueryString'
+
 export const getReturnUrl = () => {
   if (!window || !window.location) {
     return null
@@ -16,7 +19,12 @@ export const getDefaultRedirectUrl = isHeaderLogin => {
 }
 
 export const jsRedirect = ({ runtime, isHeaderLogin }) => {
-  const url = getReturnUrl() || getDefaultRedirectUrl(isHeaderLogin)
+  const url =
+    getReturnUrl() ||
+    getDefaultRedirectUrl(isHeaderLogin) ||
+    `${ROOT_PATH}/?${composeQueryString({
+      __bindingAddress: BINDING_ADDRESS,
+    })}`
 
   if (!url) {
     return

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -12,7 +12,7 @@ export const getDefaultRedirectUrl = isHeaderLogin => {
   if (isHeaderLogin) {
     return `${window.location.pathname}${window.location.search}`
   }
-  return '/'
+  return null
 }
 
 export const jsRedirect = ({ runtime, isHeaderLogin }) => {

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -1,5 +1,6 @@
-import { BINDING_ADDRESS, ROOT_PATH } from '../common/global'
+import { ROOT_PATH } from '../common/global'
 import composeQueryString from './composeQueryString'
+import getBindingAddress from './getBindingAddress'
 
 export const getReturnUrl = () => {
   if (!window || !window.location) {
@@ -23,7 +24,7 @@ export const jsRedirect = ({ runtime, isHeaderLogin }) => {
     getReturnUrl() ||
     getDefaultRedirectUrl(isHeaderLogin) ||
     `${ROOT_PATH}/?${composeQueryString({
-      __bindingAddress: BINDING_ADDRESS,
+      __bindingAddress: getBindingAddress(),
     })}`
 
   if (!url) {

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -1,5 +1,4 @@
 import { ROOT_PATH } from '../common/global'
-import composeQueryString from './composeQueryString'
 import getBindingAddress from './getBindingAddress'
 
 export const getReturnUrl = () => {
@@ -20,15 +19,13 @@ export const getDefaultRedirectUrl = isHeaderLogin => {
 }
 
 export const jsRedirect = ({ runtime, isHeaderLogin }) => {
-  const url =
-    getReturnUrl() ||
-    getDefaultRedirectUrl(isHeaderLogin) ||
-    `${ROOT_PATH}/?${composeQueryString({
-      __bindingAddress: getBindingAddress(),
-    })}`
+  const url = getReturnUrl() || getDefaultRedirectUrl(isHeaderLogin)
 
   if (!url) {
-    return
+    const queryString = new URLSearchParams({
+      __bindingAddress: getBindingAddress(),
+    }).toString()
+    return `${ROOT_PATH}/?${queryString}`
   }
 
   runtime.navigate({


### PR DESCRIPTION
#### What is the purpose of this pull request?
Consider binding issues in redirects

#### What problem is this solving?
- When the header behavior is LINK, it passes `__bindingAddress` in navigation
- When the header behavior is LINK, it adds the current query string to the `returnUrl`
- When `returnUrl` doesn't exist, redirect to default url defined by `vtex.react-vtexid`

#### How should this be manually tested?

Go into
https://rafaprtest--powerplanet.myvtex.com/login?__bindingAddress=www.powerplanetonline.com/pt
and log in. You will be redirected to the home page with the same `__bindingAddress`, as opposed to `www.powerplanetonline.com/es` (that happens in the master workspace)

You can also check this doesn't break anything in
https://rafarubim--storecomponents.myvtex.com/
(this store has server-side rendering)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

[ch37737]