### PR TITLE
Fix/google maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Injected google scripts (like `google map`) breaking the login
+
 ## [2.34.1] - 2020-06-04
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.34.2-beta.0",
+  "version": "2.34.2-beta.1",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.34.1",
+  "version": "2.34.2-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -19,6 +19,9 @@ const isBrowserSupported = () => {
   return ua.indexOf('Chrome') >= 0 || ua.indexOf('Firefox') >= 0
 }
 
+const getWindowHasGoogleScript = () =>
+  window && window.google && window.google.accounts && window.google.accounts.id
+
 const OneTapSignin = ({
   shouldOpen,
   page,
@@ -28,12 +31,6 @@ const OneTapSignin = ({
   const formRef = useRef()
   const { account } = useRuntime()
   const [startSession] = serviceHooks.useStartLoginSession()
-
-  const windowHasGoogleScript =
-    window &&
-    window.google &&
-    window.google.accounts &&
-    window.google.accounts.id
 
   const prompt = useCallback(clientId => {
     google.accounts.id.initialize({
@@ -75,7 +72,7 @@ const OneTapSignin = ({
 
       startSession()
 
-      if (windowHasGoogleScript) {
+      if (getWindowHasGoogleScript()) {
         prompt(clientId)
       } else {
         window.onGoogleLibraryLoad = () => {
@@ -84,14 +81,14 @@ const OneTapSignin = ({
       }
     })
     return () => {
-      if (!windowHasGoogleScript) return
+      if (!getWindowHasGoogleScript()) return
       google.accounts.id.cancel()
     }
-  }, [account, windowHasGoogleScript, prompt, shouldOpen, startSession])
+  }, [account, prompt, shouldOpen, startSession])
 
   return shouldOpen ? (
     <>
-      {!windowHasGoogleScript && (
+      {!getWindowHasGoogleScript() && (
         <Helmet>
           <script src="https://accounts.google.com/gsi/client" />
         </Helmet>
@@ -147,7 +144,7 @@ export const OneTapSignOut = () => {
   if (window.localStorage) {
     localStorage.setItem('gsi_auto', 'false')
   }
-  if (window.google && window.google.accounts && window.google.accounts.id) {
+  if (getWindowHasGoogleScript()) {
     google.accounts.id.disableAutoSelect()
   }
 }

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -29,6 +29,12 @@ const OneTapSignin = ({
   const { account } = useRuntime()
   const [startSession] = serviceHooks.useStartLoginSession()
 
+  const windowHasGoogleScript =
+    window &&
+    window.google &&
+    window.google.accounts &&
+    window.google.accounts.id
+
   const prompt = useCallback(clientId => {
     google.accounts.id.initialize({
       client_id: clientId,
@@ -69,7 +75,7 @@ const OneTapSignin = ({
 
       startSession()
 
-      if (window.google) {
+      if (windowHasGoogleScript) {
         prompt(clientId)
       } else {
         window.onGoogleLibraryLoad = () => {
@@ -78,14 +84,14 @@ const OneTapSignin = ({
       }
     })
     return () => {
-      if (!window || !window.google) return
+      if (!windowHasGoogleScript) return
       google.accounts.id.cancel()
     }
-  }, [account, prompt, shouldOpen, startSession])
+  }, [account, windowHasGoogleScript, prompt, shouldOpen, startSession])
 
   return shouldOpen ? (
     <>
-      {!window.google && (
+      {!windowHasGoogleScript && (
         <Helmet>
           <script src="https://accounts.google.com/gsi/client" />
         </Helmet>
@@ -135,6 +141,13 @@ const Wrapper = props => {
 export default Wrapper
 
 export const OneTapSignOut = () => {
-  window.localStorage && localStorage.setItem('gsi_auto', 'false')
-  window.google && google.accounts.id.disableAutoSelect()
+  if (!window) {
+    return
+  }
+  if (window.localStorage) {
+    localStorage.setItem('gsi_auto', 'false')
+  }
+  if (window.google && window.google.accounts && window.google.accounts.id) {
+    google.accounts.id.disableAutoSelect()
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This improves checks for `window.google` object

#### What problem is this solving?
Scripts injected by google like `google maps` create a `window.google` object. This currently breaks the code used for `google one tap`.

#### How should this be manually tested?

You can check the linked app here:
https://rafaprtest--storecomponents.myvtex.com/_v/segment/admin-login/v1/login?returnUrl=%2F%3F

A beta version is installed here. You can try out the OneTap login to see it still working:
https://storecomponents.myvtex.com/_v/segment/admin-login/v1/login?returnUrl=%2F%3F

A beta version is also installed here, with the google maps script:
https://google--unimarc.myvtex.com/

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Clubhouse hooks
[ch38767]