### PR TITLE
Fix/one tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Google OneTap not working
+- Unit tests were broken
+
 ## [2.34.2] - 2020-06-09
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.34.2",
+  "version": "2.34.3-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/__tests__/__snapshots__/Login.test.js.snap
+++ b/react/__tests__/__snapshots__/Login.test.js.snap
@@ -99,7 +99,7 @@ exports[
               class="contentContainer shadow-3 mt3"
             >
               <div
-                class="content flex relative bg-base justify-around overflow-visible pa4 center items-start-ns contentInitialScreen items-baseline"
+                class="content content--accountOptions flex relative bg-base justify-around overflow-visible pa4 center items-start-ns contentInitialScreen items-baseline"
               >
                 <div
                   class="contentForm dn ph4 contentFormVisible db "
@@ -193,7 +193,7 @@ exports[
               class="contentContainer shadow-3 mt3"
             >
               <div
-                class="content flex relative bg-base justify-around overflow-visible pa4 center items-start-ns contentInitialScreen items-baseline"
+                class="content content--accountOptions flex relative bg-base justify-around overflow-visible pa4 center items-start-ns contentInitialScreen items-baseline"
               >
                 <div
                   class="contentForm dn ph4 contentFormVisible db "
@@ -285,7 +285,7 @@ exports[`<Login /> component should match snapshot without profile 1`] = `
               class="contentContainer shadow-3 mt3"
             >
               <div
-                class="content flex relative bg-base justify-around overflow-visible pa4 center items-baseline-ns contentInitialScreen items-baseline"
+                class="content content--emailVerification flex relative bg-base justify-around overflow-visible pa4 center items-baseline-ns contentInitialScreen items-baseline"
               >
                 <div
                   class="options"

--- a/react/__tests__/__snapshots__/LoginContent.test.js.snap
+++ b/react/__tests__/__snapshots__/LoginContent.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<LoginContent /> component should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="content flex relative bg-base justify-around overflow-visible pa4 center items-baseline-ns contentInitialScreen items-baseline"
+    class="content content--emailVerification flex relative bg-base justify-around overflow-visible pa4 center items-baseline-ns contentInitialScreen items-baseline"
   >
     <div
       class="options"
@@ -124,7 +124,7 @@ exports[`<LoginContent /> component should match snapshot 1`] = `
 exports[`<LoginContent /> component should match snapshot when loading 1`] = `
 <DocumentFragment>
   <div
-    class="content flex relative bg-base justify-around overflow-visible pa4 center items-baseline-ns contentInitialScreen items-baseline"
+    class="content content--emailVerification flex relative bg-base justify-around overflow-visible pa4 center items-baseline-ns contentInitialScreen items-baseline"
   >
     <div
       class="options"

--- a/react/common/global.js
+++ b/react/common/global.js
@@ -9,4 +9,5 @@ export const GoogleOneTapAlignment = {
   RIGHT: 'Right',
   LEFT: 'Left',
 }
-export const ROOT_PATH = (__RUNTIME__ && __RUNTIME__.rootPath) || ''
+export const getRootPath = () =>
+  (window && window.__RUNTIME__ && window.__RUNTIME__.rootPath) || ''

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -29,8 +29,12 @@ const OneTapSignin = ({
   alignment = GoogleOneTapAlignment.RIGHT,
 }) => {
   const formRef = useRef()
-  const { account } = useRuntime()
-  const [startSession] = serviceHooks.useStartLoginSession()
+  const { account, rootPath } = useRuntime()
+  const [startSession] = serviceHooks.useStartLoginSession({
+    actionArgs: {
+      returnUrl: onLoginPage(page) ? rootPath || '/' : window.location.href,
+    },
+  })
 
   const prompt = useCallback(clientId => {
     google.accounts.id.initialize({
@@ -117,18 +121,13 @@ OneTapSignin.propTypes = {
 }
 
 const Wrapper = props => {
-  const { page, rootPath } = useRuntime()
+  const { page } = useRuntime()
 
   if (!isBrowserSupported() || !window.location) return null
 
   return (
     <Suspense fallback={null}>
-      <AuthStateLazy
-        skip
-        scope="STORE"
-        parentAppId={SELF_APP_NAME_AND_VERSION}
-        returnUrl={onLoginPage(page) ? rootPath || '/' : window.location.href}
-      >
+      <AuthStateLazy skip scope="STORE" parentAppId={SELF_APP_NAME_AND_VERSION}>
         <OneTapSignin {...props} page={page} />
       </AuthStateLazy>
     </Suspense>

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -1,4 +1,4 @@
-import { ROOT_PATH } from '../common/global'
+import { getRootPath } from '../common/global'
 import getBindingAddress from './getBindingAddress'
 
 export const getReturnUrl = () => {
@@ -27,7 +27,7 @@ export const jsRedirect = ({ runtime, isHeaderLogin }) => {
     const queryString = __bindingAddress
       ? new URLSearchParams({ __bindingAddress }).toString()
       : ''
-    return `${ROOT_PATH}/?${queryString}`
+    return `${getRootPath()}/?${queryString}`
   }
 
   runtime.navigate({


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the Google One Tap login

#### What problem is this solving?
The google OneTap had broken because of an accidental breaking change in `react-vtexid`. It had removed the consumption of `returnUrl` from the `AuthState` provider.
This also fixes the unit tests that were previously broken.

#### How should this be manually tested?

This beta version was installed in the `storecomponents` tenant. Go there and check the Google one-tap login works correctly:
https://storecomponents.myvtex.com/

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/85096632-473ed900-b1cb-11ea-89af-9bb92a0c19e4.png)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
