### PR TITLE
Chore/app id log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Usage of service hooks to address future breaking changes in `react-vtexid`
+
 ## [2.34.3] - 2020-06-23
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.34.3",
+  "version": "2.34.4-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -405,6 +405,7 @@ const LoginContentWrapper = props => {
     ,
     { loading: loadingSendAccessKey, error: errorSendAccessKey },
   ] = serviceHooks.useSendAccessKey({
+    parentAppId: SELF_APP_NAME_AND_VERSION,
     autorun: isCreatePassFlow,
     actionArgs: {
       useNewSession: true,

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -31,6 +31,8 @@ const OneTapSignin = ({
   const formRef = useRef()
   const { account, rootPath } = useRuntime()
   const [startSession] = serviceHooks.useStartLoginSession({
+    scope: 'STORE',
+    parentAppId: SELF_APP_NAME_AND_VERSION,
     actionArgs: {
       returnUrl: onLoginPage(page) ? rootPath || '/' : window.location.href,
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?
This prepares for future breaking changes in "react-vtexid"

#### What problem is this solving?
The options `scope` and `parentAppId` won't be consumed from the `AuthState` provider anymore, so they were added to the service hooks options.

#### How should this be manually tested?

You can manually test the login app here:
http://rafaprtest2--storecomponents.myvtex.com/

You can also clone the rep and go into the `react/` folder, then run `yarn test` to run the unit tests.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [X] Chore

#### Clubhouse hooks
[ch39078]