### PR TITLE
Change truncate of user name from JS to CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change truncate of user name from JS to CSS.
+
 ## [2.34.4] - 2020-07-07
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.34.4",
+  "version": "2.34.5-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -66,7 +66,7 @@ class LoginComponent extends Component {
       <Fragment>
         {sessionProfile ? (
           <span
-            className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}
+            className={`${styles.profile} truncate t-action--small order-1 pl4 ${labelClasses} dn db-l`}
           >
             {translate('store/login.hello', intl)}{' '}
             {sessionProfile.firstName || sessionProfile.email}

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -11,7 +11,6 @@ import { IconProfile } from 'vtex.store-icons'
 import Overlay from 'vtex.react-portal/Overlay'
 import { ButtonWithIcon } from 'vtex.styleguide'
 
-import { truncateString } from '../utils/format-string'
 import { translate } from '../utils/translate'
 import { LoginPropTypes } from '../propTypes'
 import OneTapSignin from './OneTapSignin'
@@ -70,7 +69,7 @@ class LoginComponent extends Component {
             className={`${styles.profile} t-action--small order-1 pl4 ${labelClasses} dn db-l`}
           >
             {translate('store/login.hello', intl)}{' '}
-            {sessionProfile.firstName || truncateString(sessionProfile.email)}
+            {sessionProfile.firstName || sessionProfile.email}
           </span>
         ) : (
           iconLabel && (

--- a/react/styles.css
+++ b/react/styles.css
@@ -5,10 +5,7 @@
 .contentFormVisible {}
 
 .profile {
-  text-overflow: ellipsis;
   max-width: 130px;
-  white-space: nowrap;
-  overflow: hidden;
 }
 
 .label {}

--- a/react/styles.css
+++ b/react/styles.css
@@ -4,7 +4,12 @@
 
 .contentFormVisible {}
 
-.profile {}
+.profile {
+  text-overflow: ellipsis;
+  max-width: 130px;
+  white-space: nowrap;
+  overflow: hidden;
+}
 
 .label {}
 

--- a/react/utils/format-string.js
+++ b/react/utils/format-string.js
@@ -1,8 +1,3 @@
 import Slugify from 'slugify'
 
-export const truncateString = str => {
-  const MAX_LENGTH = 7
-  return str <= MAX_LENGTH ? str : str.substring(0, MAX_LENGTH).concat('...')
-}
-
 export const slugify = string => Slugify(string, { replacement: '-', lower: true })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use CSS to truncate the name of the user.

#### What problem is this solving?

Make it possible to change the width of the component with CSS to show more characters of the user name.

#### How should this be manually tested?

https://breno--storecomponents.myvtex.com/

#### Screenshots or example usage

![truncate](https://user-images.githubusercontent.com/284515/86403246-b57fa300-bc83-11ea-93c5-efb8b731cf52.gif)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
