### PR TITLE
Feature/oauth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- OAuth error handling (for both popup and redirect flows), showing messages in case of errors
+
 ## [2.34.9] - 2020-07-16
 
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.34.9",
+  "version": "2.35.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,4 +1,7 @@
 {
+  "store/error.oauth.unknown": "store/error.oauth.unknown",
+  "store/error.oauth.refresh": "store/error.oauth.refresh",
+  "store/error.oauth.missingEmail": "store/error.oauth.missingEmail",
   "store/loginOptions.title": "store/loginOptions.title",
   "store/loginOptions.emailVerification": "store/loginOptions.emailVerification",
   "store/loginOptions.emailAndPassword": "store/loginOptions.emailAndPassword",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,7 @@
 {
+  "store/error.oauth.unknown": "Sorry, an unexpected error occurred. Please, try again.",
+  "store/error.oauth.refresh": "Sorry, it is likely that you tried to refresh the browser during the process. Please, try again.",
+  "store/error.oauth.missingEmail": "Sorry, we didn't receive your e-mail. Please, check your permissions or contact the responsible company.",
   "store/loginOptions.title": "Choose a sign-in option",
   "store/loginOptions.emailVerification": "Receive access code by e-mail",
   "store/loginOptions.emailAndPassword": "Sign in with e-mail and password",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,7 @@
 {
+  "store/error.oauth.unknown": "Lo sentimos, se produjo un error inesperado. Por favor, inténtelo de nuevo.",
+  "store/error.oauth.refresh": "Lo sentimos, probablemente trató de actualizar su navegador durante el proceso. Por favor, inténtelo de nuevo.",
+  "store/error.oauth.missingEmail": "Lo sentimos, no recibimos su correo electrónico. Por favor, compruebe sus permisos o póngase en contacto con la empresa responsable.",
   "store/loginOptions.title": "Escoja una opción para entrar",
   "store/loginOptions.emailVerification": "Recibir código de acceso por e-mail",
   "store/loginOptions.emailAndPassword": "Entrar con e-mail y contraseña",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,4 +1,7 @@
 {
+  "store/error.oauth.unknown": "Desculpe, ocorreu um erro inesperado. Por favor, tente novamente.",
+  "store/error.oauth.refresh": "Desculpe, é provável que você tentou atualizar o browser durante o processo. Por favor, tente novamente.",
+  "store/error.oauth.missingEmail": "Desculpe, não recebemos o seu e-mail. Por favor, confira suas permissões ou entre em contato com a empresa responsável.",
   "store/loginOptions.title": "Escolha uma opção para entrar",
   "store/loginOptions.emailVerification": "Receber código de acesso por e-mail",
   "store/loginOptions.emailAndPassword": "Entrar com e-mail e senha",

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -24,6 +24,7 @@ import { AuthStateLazy, AuthServiceLazy, serviceHooks } from 'vtex.react-vtexid'
 import { SELF_APP_NAME_AND_VERSION } from '../common/global'
 import getUserEmailQuery from '../utils/getUserEmailQuery'
 import getFlowStateQuery from '../utils/getFlowStateQuery'
+import getErrorQuery from '../utils/getErrorQuery'
 import getSessionProfile from '../utils/getSessionProfile'
 import { getReturnUrl, getDefaultRedirectUrl, jsRedirect } from '../utils/redirect'
 import styleModifierByStep from '../utils/styleModifierByStep'
@@ -200,6 +201,9 @@ class LoginContent extends Component {
     if (!loginOptions) return [false, null]
     const { accessKey, oAuthProviders, password } = loginOptions
     const { runtime } = this.props
+    if (getErrorQuery(runtime)) {
+      return [false, null]
+    }
     if (runtime && runtime.query && runtime.query.oAuthRedirect) {
       const redirectProvider =
         oAuthProviders &&

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -73,7 +73,7 @@ const LoginOptions = ({
   return (
     <div className={classes}>
       <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
-      <FormError show={loginError}>{loginError}</FormError>
+      <FormError show={!!loginError}>{loginError}</FormError>
       <ul className={`${styles.optionsList} list pa0`}>
         <Fragment>
           {options.accessKeyAuthentication &&

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Fragment, useCallback, useMemo, useState } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
-import { ExtensionContainer } from 'vtex.render-runtime'
+import { ExtensionContainer, useRuntime } from 'vtex.render-runtime'
 import { Button } from 'vtex.styleguide'
 
 import FacebookIcon from '../images/FacebookIcon'
@@ -12,6 +12,7 @@ import FormTitle from './FormTitle'
 import OAuth from './OAuth'
 import styles from '../styles.css'
 import FormError from './FormError'
+import getErrorQuery from '../utils/getErrorQuery'
 
 const PROVIDERS_ICONS = {
   Google: GoogleIcon,
@@ -31,7 +32,9 @@ const LoginOptions = ({
   currentStep,
   onOptionsClick,
 }) => {
-  const [loginError, setLoginError] = useState(null)
+  const runtime = useRuntime()
+  const errorQuery = useMemo(() => getErrorQuery(runtime), [runtime])
+  const [loginError, setLoginError] = useState(errorQuery)
 
   const handleOAuthError = useCallback(err => setLoginError(err), [])
 

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -13,6 +13,7 @@ import OAuth from './OAuth'
 import styles from '../styles.css'
 import FormError from './FormError'
 import getErrorQuery from '../utils/getErrorQuery'
+import getOAuthErrorMessage from '../utils/getOAuthErrorMessage'
 
 const PROVIDERS_ICONS = {
   Google: GoogleIcon,
@@ -33,10 +34,16 @@ const LoginOptions = ({
   onOptionsClick,
 }) => {
   const runtime = useRuntime()
-  const errorQuery = useMemo(() => getErrorQuery(runtime), [runtime])
-  const [loginError, setLoginError] = useState(errorQuery)
+  const initialOAuthErrorMessage = useMemo(() => {
+    const errorQuery = getErrorQuery(runtime)
+    return errorQuery && getOAuthErrorMessage(errorQuery)
+  }, [runtime])
+  const [loginError, setLoginError] = useState(initialOAuthErrorMessage)
 
-  const handleOAuthError = useCallback(err => setLoginError(err), [])
+  const handleOAuthError = useCallback(err => {
+    const msg = getOAuthErrorMessage(err)
+    setLoginError(msg)
+  }, [])
 
   const handleOptionClick = useCallback(
     el => () => {

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -1,9 +1,8 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component, Fragment } from 'react'
+import React, { Component, Fragment, useCallback, useMemo } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
 import { ExtensionContainer } from 'vtex.render-runtime'
-
 import { Button } from 'vtex.styleguide'
 
 import FacebookIcon from '../images/FacebookIcon'
@@ -11,7 +10,6 @@ import GoogleIcon from '../images/GoogleIcon'
 import { translate } from '../utils/translate'
 import FormTitle from './FormTitle'
 import OAuth from './OAuth'
-
 import styles from '../styles.css'
 
 const PROVIDERS_ICONS = {
@@ -20,123 +18,131 @@ const PROVIDERS_ICONS = {
 }
 
 /** LoginOptions tab component. Displays a list of login options */
-class LoginOptions extends Component {
-  handleOptionClick = el => () => {
-    this.props.onOptionsClick(el)
-  }
+const LoginOptions = ({
+  className,
+  title,
+  fallbackTitle,
+  options,
+  onLoginSuccess,
+  intl,
+  isAlwaysShown,
+  providerPasswordButtonLabel,
+  currentStep,
+  onOptionsClick,
+}) => {
+  const handleOptionClick = useCallback(
+    el => () => {
+      onOptionsClick(el)
+    },
+    [onOptionsClick]
+  )
 
-  showOption = (option, optionName) => {
-    const { isAlwaysShown, currentStep, options } = this.props
-    return (
-      options &&
-      ((options[option] && !isAlwaysShown) || currentStep !== optionName)
-    )
-  }
+  const showOption = useCallback(
+    (option, optionName) => {
+      return (
+        options &&
+        ((options[option] && !isAlwaysShown) || currentStep !== optionName)
+      )
+    },
+    [isAlwaysShown, currentStep, options]
+  )
 
-  render() {
-    const {
-      className,
-      title,
-      fallbackTitle,
-      options,
-      onLoginSuccess,
-      intl,
-      isAlwaysShown,
-      providerPasswordButtonLabel,
-    } = this.props
+  const classes = useMemo(
+    () =>
+      classNames(styles.options, className, {
+        [styles.optionsSticky]: isAlwaysShown,
+      }),
+    [className, isAlwaysShown]
+  )
 
-    const classes = classNames(styles.options, className, {
-      [styles.optionsSticky]: isAlwaysShown,
-    })
-
-    return (
-      <div className={classes}>
-        <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
-        <ul className={`${styles.optionsList} list pa0`}>
-          <Fragment>
-            {options.accessKeyAuthentication &&
-              this.showOption(
-                'accessKeyAuthentication',
-                'store/loginOptions.emailVerification'
-              ) && (
+  return (
+    <div className={classes}>
+      <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
+      <ul className={`${styles.optionsList} list pa0`}>
+        <Fragment>
+          {options.accessKeyAuthentication &&
+            showOption(
+              'accessKeyAuthentication',
+              'store/loginOptions.emailVerification'
+            ) && (
               <li className={`${styles.optionsListItem} mb3`}>
-                <div className={classNames(styles.button, styles.accessCodeOptionBtn)}>
+                <div
+                  className={classNames(
+                    styles.button,
+                    styles.accessCodeOptionBtn
+                  )}
+                >
                   <Button
                     variation="secondary"
-                    onClick={this.handleOptionClick(
+                    onClick={handleOptionClick(
                       'store/loginOptions.emailVerification'
                     )}
                   >
                     <span>
-                      {translate(
-                        'store/loginOptions.emailVerification',
-                        intl
-                      )}
+                      {translate('store/loginOptions.emailVerification', intl)}
                     </span>
                   </Button>
                 </div>
               </li>
             )}
-            {options.classicAuthentication &&
-              this.showOption(
-                'classicAuthentication',
-                'store/loginOptions.emailAndPassword'
-              ) && (
+          {options.classicAuthentication &&
+            showOption(
+              'classicAuthentication',
+              'store/loginOptions.emailAndPassword'
+            ) && (
               <li className={`${styles.optionsListItem} mb3`}>
-                <div className={classNames(styles.button, styles.emailPasswordOptionBtn)}>
+                <div
+                  className={classNames(
+                    styles.button,
+                    styles.emailPasswordOptionBtn
+                  )}
+                >
                   <Button
                     variation="secondary"
-                    onClick={this.handleOptionClick(
+                    onClick={handleOptionClick(
                       'store/loginOptions.emailAndPassword'
                     )}
                   >
                     <span>
                       {providerPasswordButtonLabel ||
-                          translate(
-                            'store/loginOptions.emailAndPassword',
-                            intl
-                          )}
+                        translate('store/loginOptions.emailAndPassword', intl)}
                     </span>
                   </Button>
                 </div>
               </li>
             )}
-            {options.providers &&
-              options.providers.map(({ providerName }, index) => {
-                const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
-                return (
-                  <li
-                    className={`${styles.optionsListItem} mb3`}
-                    key={`${providerName}-${index}`}
+          {options.providers &&
+            options.providers.map(({ providerName }, index) => {
+              const hasIcon = PROVIDERS_ICONS.hasOwnProperty(providerName)
+              return (
+                <li
+                  className={`${styles.optionsListItem} mb3`}
+                  key={`${providerName}-${index}`}
+                >
+                  <OAuth
+                    provider={providerName}
+                    onLoginSuccess={onLoginSuccess}
                   >
-                    <OAuth
-                      provider={providerName}
-                      onLoginSuccess={onLoginSuccess}
-                    >
-                      {hasIcon
-                        ? React.createElement(
-                          PROVIDERS_ICONS[providerName],
-                          null
-                        )
-                        : null}
-                    </OAuth>
-                  </li>
-                )
-              })}
-          </Fragment>
-          <li
-            className={`${styles.optionsListItem} ${styles.optionsListItemContainer} mb3`}
-          >
-            <ExtensionContainer id="container" />
-          </li>
-        </ul>
-      </div>
-    )
-  }
+                    {hasIcon
+                      ? React.createElement(PROVIDERS_ICONS[providerName], null)
+                      : null}
+                  </OAuth>
+                </li>
+              )
+            })}
+        </Fragment>
+        <li
+          className={`${styles.optionsListItem} ${styles.optionsListItemContainer} mb3`}
+        >
+          <ExtensionContainer id="container" />
+        </li>
+      </ul>
+    </div>
+  )
 }
 
 LoginOptions.propTypes = {
-  /** Intl object*/
+  /** Intl object */
   intl: intlShape,
   /** Function to change de active tab */
   onOptionsClick: PropTypes.func.isRequired,

--- a/react/components/LoginOptions.js
+++ b/react/components/LoginOptions.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import React, { Component, Fragment, useCallback, useMemo } from 'react'
+import React, { Fragment, useCallback, useMemo, useState } from 'react'
 import { injectIntl, intlShape } from 'react-intl'
 import { ExtensionContainer } from 'vtex.render-runtime'
 import { Button } from 'vtex.styleguide'
@@ -11,6 +11,7 @@ import { translate } from '../utils/translate'
 import FormTitle from './FormTitle'
 import OAuth from './OAuth'
 import styles from '../styles.css'
+import FormError from './FormError'
 
 const PROVIDERS_ICONS = {
   Google: GoogleIcon,
@@ -30,6 +31,10 @@ const LoginOptions = ({
   currentStep,
   onOptionsClick,
 }) => {
+  const [loginError, setLoginError] = useState(null)
+
+  const handleOAuthError = useCallback(err => setLoginError(err), [])
+
   const handleOptionClick = useCallback(
     el => () => {
       onOptionsClick(el)
@@ -44,7 +49,7 @@ const LoginOptions = ({
         ((options[option] && !isAlwaysShown) || currentStep !== optionName)
       )
     },
-    [isAlwaysShown, currentStep, options]
+    [options, isAlwaysShown, currentStep]
   )
 
   const classes = useMemo(
@@ -58,6 +63,7 @@ const LoginOptions = ({
   return (
     <div className={classes}>
       <FormTitle>{title || translate(fallbackTitle, intl)}</FormTitle>
+      <FormError show={loginError}>{loginError}</FormError>
       <ul className={`${styles.optionsList} list pa0`}>
         <Fragment>
           {options.accessKeyAuthentication &&
@@ -122,6 +128,7 @@ const LoginOptions = ({
                   <OAuth
                     provider={providerName}
                     onLoginSuccess={onLoginSuccess}
+                    onOAuthError={handleOAuthError}
                   >
                     {hasIcon
                       ? React.createElement(PROVIDERS_ICONS[providerName], null)

--- a/react/components/OAuth.js
+++ b/react/components/OAuth.js
@@ -26,13 +26,18 @@ class OAuth extends Component {
     children: PropTypes.node,
     /** Function called after login success */
     onLoginSuccess: PropTypes.func.isRequired,
+    /** Function called if oauth flow ends in an error */
+    onOAuthError: PropTypes.func.isRequired,
   }
 
+  handleOAuthPopupFailure = err =>
+    this.props.onOAuthError(err.details)
+
   render() {
-    const { intl, children, provider, onLoginSuccess } = this.props
+    const { intl, children, provider, onLoginSuccess, onLoginError } = this.props
     return (
       <div className={className(styles.button, styles.buttonSocial, styleByProviderName[provider] || styles.customOAuthOptionBtn)}>
-        <AuthServiceLazy.OAuthPopup useNewSession provider={provider} onSuccess={() => onLoginSuccess()}>
+        <AuthServiceLazy.OAuthPopup useNewSession provider={provider} onSuccess={() => onLoginSuccess()} onFailure={this.handleOAuthPopupFailure}>
           {({ loading, action: openOAuthPopup }) => (
             <Button
               isLoading={loading}

--- a/react/components/OAuthAutoRedirect.js
+++ b/react/components/OAuthAutoRedirect.js
@@ -41,10 +41,13 @@ OAuthAutoRedirect.propTypes = {
 
 function Wrapper({ provider, ...props }) {
   const errorFallbackUrl = useMemo(() => {
-    const location = window && window.location
-    const currentDomain = location && location.origin
-    const currentSearch = location && location.search
-    const currentHash = location && location.hash
+    const {
+      location: {
+        origin: currentDomain = '',
+        search: currentSearch = '',
+        hash: currentHash = '',
+      } = {},
+    } = window || {}
     return new URL(
       `${getRootPath()}/login${currentSearch}${currentHash}`,
       currentDomain

--- a/react/components/OAuthAutoRedirect.js
+++ b/react/components/OAuthAutoRedirect.js
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import { Spinner } from 'vtex.styleguide'
 import { AuthServiceLazy } from 'vtex.react-vtexid'
 
+import { getRootPath } from '../common/global'
 import styles from '../styles.css'
 
 function OAuthAutoRedirect({ intl, provider, redirect }) {
@@ -39,8 +40,23 @@ OAuthAutoRedirect.propTypes = {
 }
 
 function Wrapper({ provider, ...props }) {
+  const errorFallbackUrl = useMemo(() => {
+    const location = window && window.location
+    const currentDomain = location && location.origin
+    const currentSearch = location && location.search
+    const currentHash = location && location.hash
+    return new URL(
+      `${getRootPath()}/login${currentSearch}${currentHash}`,
+      currentDomain
+    ).href
+  }, [])
+
   return (
-    <AuthServiceLazy.OAuthRedirect useNewSession provider={provider}>
+    <AuthServiceLazy.OAuthRedirect
+      errorFallbackUrl={errorFallbackUrl}
+      useNewSession
+      provider={provider}
+    >
       {({ loading, action: redirectToOAuthPage }) => (
         <OAuthAutoRedirect
           {...props}

--- a/react/components/OAuthAutoRedirect.js
+++ b/react/components/OAuthAutoRedirect.js
@@ -21,13 +21,16 @@ function OAuthAutoRedirect({ intl, provider, redirect }) {
             { provider }
           )}
         </p>
-        <div className={`self-center c-emphasis ${styles.oauthAutoRedirectLoading}`}>
+        <div
+          className={`self-center c-emphasis ${styles.oauthAutoRedirectLoading}`}
+        >
           <Spinner color="currentColor" size={24} />
         </div>
       </div>
     </div>
   )
 }
+
 OAuthAutoRedirect.propTypes = {
   redirect: PropTypes.func.isRequired,
   provider: PropTypes.string.isRequired,
@@ -49,6 +52,7 @@ function Wrapper({ provider, ...props }) {
     </AuthServiceLazy.OAuthRedirect>
   )
 }
+
 Wrapper.propTypes = {
   provider: PropTypes.string.isRequired,
 }

--- a/react/utils/getErrorQuery.js
+++ b/react/utils/getErrorQuery.js
@@ -1,0 +1,5 @@
+const getErrorQuery = runtime => {
+  return runtime && runtime.query && runtime.query.error
+}
+
+export default getErrorQuery

--- a/react/utils/getOAuthErrorMessage.jsx
+++ b/react/utils/getOAuthErrorMessage.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+
+const messageByOAuthError = {
+  AuthorizationCodeAlreadyUsed: (
+    <FormattedMessage id="store/error.oauth.refresh" />
+  ),
+  MissingUserEmail: <FormattedMessage id="store/error.oauth.missingEmail" />,
+}
+
+const getOAuthErrorMessage = err => {
+  const message = messageByOAuthError[err]
+  return message || <FormattedMessage id="store/error.oauth.unknown" />
+}
+
+export default getOAuthErrorMessage


### PR DESCRIPTION
#### What is the purpose of this pull request?
Handle errors in OAuth flow by presenting error messages

#### What problem is this solving?
⚠️ This PR depends on https://github.com/vtex/react-vtexid/pull/111 ⚠️

Redirect OAuth flow: Pass `{{currentDomain}}/login{{currentQueryString}}{{currentHash}}` as `errorFallbackUrl` to the API. Also, the app receives the `error` query string (sent when the API redirects to the `errorFallbackUrl`) and displays an error message.
Popup OAuth flow: When the onFailure callback is called (in that case, the popup is automatically closed), the app displays an error message related to the error received.

#### How should this be manually tested?

Both popup and redirect oAuth flows can be tested in the linked version of the `login` app:

**Popup flow**

Go into
https://rafaprtest7--storecomponents.myvtex.com/
To simulate OAuth errors you'll need a proxy to rewrite the response of `/api/vtexid/pub/authentication/oauth/redirect` calls to:
```
STATUS 302
Header Location: `/api/vtexid/oauth/error?error=MissingUserEmail`
```
Try to log on to the store through `Google`. You'll see an error message.

**Redirect flow**

To simulate OAuth errors you'll need a proxy to rewrite the response of `/api/vtexid/pub/authentication/oauth/redirect` calls to:
```
STATUS 302
Header Location: `/login?error=MissingUserEmail`
```
Then, go into
https://rafaprtest7--storecomponents.myvtex.com/login?oAuthRedirect=Google
You'll be automatically redirected to `Google`, then back to the login page. You'll see an error message.

You can also run the unit tests by running `cd react`/`yarn test`

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Clubhouse hooks
[ch38464]