### PR TITLE
Chore/import hooks directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Import hooks directly instead of the whole "serviceHooks" bundle
+
 ## [2.35.3] - 2020-08-12
 
 ## [2.35.2] - 2020-08-11

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.35.3",
+  "version": "2.35.4-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/__mocks__/vtex.react-vtexid.js
+++ b/react/__mocks__/vtex.react-vtexid.js
@@ -62,8 +62,6 @@ AuthStateLazy.IdentityProviders = jest.fn(({ children }) =>
   })
 )
 
-const serviceHooks = {
-  useSendAccessKey: () => [() => {}, { loading: false, error: false }],
-}
+const useSendAccessKey = () => [() => {}, { loading: false, error: false }]
 
-export { AuthStateLazy, serviceHooks }
+export { AuthStateLazy, useSendAccessKey }

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -20,7 +20,7 @@ import { setCookie } from '../utils/set-cookie'
 import FlowState from '../utils/FlowState'
 
 import { LoginPropTypes } from '../propTypes'
-import { AuthStateLazy, AuthServiceLazy, serviceHooks } from 'vtex.react-vtexid'
+import { AuthStateLazy, AuthServiceLazy, useSendAccessKey } from 'vtex.react-vtexid'
 import { SELF_APP_NAME_AND_VERSION } from '../common/global'
 import getUserEmailQuery from '../utils/getUserEmailQuery'
 import getFlowStateQuery from '../utils/getFlowStateQuery'
@@ -413,7 +413,7 @@ const LoginContentWrapper = props => {
   const [
     ,
     { loading: loadingSendAccessKey, error: errorSendAccessKey },
-  ] = serviceHooks.useSendAccessKey({
+  ] = useSendAccessKey({
     scope: 'STORE',
     parentAppId: SELF_APP_NAME_AND_VERSION,
     autorun: isCreatePassFlow,

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useRef, Suspense } from 'react'
 import PropTypes from 'prop-types'
 import { useRuntime, Helmet } from 'vtex.render-runtime'
-import { AuthStateLazy, serviceHooks } from 'vtex.react-vtexid'
+import { AuthStateLazy, useStartLoginAttempt } from 'vtex.react-vtexid'
 
 import {
   GoogleOneTapAlignment,
@@ -31,7 +31,7 @@ const OneTapSignin = ({
   const formRef = useRef()
   const { account, rootPath } = useRuntime()
 
-  const [startSession] = serviceHooks.useStartLoginAttempt({
+  const [startSession] = useStartLoginAttempt({
     scope: 'STORE',
     parentAppId: SELF_APP_NAME_AND_VERSION,
     loginAttempt: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Import service hooks directly instead of `serviceHooks` obj

#### What problem is this solving?
⚠️ This depends on https://github.com/vtex/react-vtexid/pull/114 ⚠️

Importing the `serviceHooks` obj includes the whole bundle of service hooks. This makes it so only the ones that are used are bundled.

#### How should this be manually tested?

https://rafaprtest4--storecomponents.myvtex.com

To run the unit tests, run `cd react` and `yarn test`

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [X] Chore

#### Clubhouse hooks
[ch39636]