### PR TITLE
Feature/hide header label [VID-50]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `hideIconLabel` prop to `login` interface
+- `hideIconLabel` prop to site-editor
+
 ## [2.35.4] - 2020-08-12
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 | `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                               | -             |
 | `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                                             | -             |
 | `iconLabel`                                        | `String`  | Set label of the login button                                                                            | -             |
+| `hideIconLabel`                                    | `Boolean` | Hide label of the login button                                                                           | false         |
 | `labelClasses`                                     | `String`  | Label's classnames                                                                                       | -             |
 | `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                                           | -             |
 | `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                              | -             |

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ Through the Storefront, you can change the `login`'s behavior and interface. How
 | `showIconProfile`                                  | `Boolean` | Enables icon `hpa-profile`                                                                               | -             |
 | `iconSize` (DEPRECATED - use icon blocks instead)  | `Number`  | Set size of the profile icon                                                                             | -             |
 | `iconLabel`                                        | `String`  | Set label of the login button                                                                            | -             |
-| `hideIconLabel`                                    | `Boolean` | Hide label of the login button                                                                           | false         |
+| `hideIconLabel`  | `boolean` | Whether the Login button label should be hidden (`true`) or not (`false`).    | `false`     |
 | `labelClasses`                                     | `String`  | Label's classnames                                                                                       | -             |
 | `providerPasswordButtonLabel`                      | `String`  | Set Password login button text                                                                           | -             |
 | `hasIdentifierExtension`                           | `Boolean` | Enables identifier extension configurations                                                              | -             |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.35.4",
+  "version": "2.36.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/messages/context.json
+++ b/messages/context.json
@@ -52,6 +52,7 @@
   "admin/editor.login.showPasswordVerificationIntoTooltip.title": "admin/editor.login.showPasswordVerificationIntoTooltip.title",
   "admin/editor.login.showIconProfile": "admin/editor.login.showIconProfile",
   "admin/editor.login.iconLabel": "admin/editor.login.iconLabel",
+  "admin/editor.login.hideIconLabel": "admin/editor.login.hideIconLabel",
   "admin/editor.login.providerPasswordButtonLabel": "admin/editor.login.providerPasswordButtonLabel",
   "admin/editor.login.hasIdentifierExtension": "admin/editor.login.hasIdentifierExtension",
   "admin/editor.login.identifierPlaceholder": "admin/editor.login.identifierPlaceholder",

--- a/messages/en.json
+++ b/messages/en.json
@@ -52,6 +52,7 @@
   "admin/editor.login.showPasswordVerificationIntoTooltip.title": "Show password format verification as tooltip",
   "admin/editor.login.showIconProfile": "Show profile icon",
   "admin/editor.login.iconLabel": "Login button label",
+  "admin/editor.login.hideIconLabel": "Hide login button label",
   "admin/editor.login.providerPasswordButtonLabel": "E-mail/Password login button label",
   "admin/editor.login.hasIdentifierExtension": "E-mail/Password user identifier extension",
   "admin/editor.login.identifierPlaceholder": "Identifier input placeholder",

--- a/messages/es.json
+++ b/messages/es.json
@@ -52,6 +52,7 @@
   "admin/editor.login.showPasswordVerificationIntoTooltip.title": "Mostrar verificación del formato de contraseña como tooltip",
   "admin/editor.login.showIconProfile": "Mostrar ícono de perfil",
   "admin/editor.login.iconLabel": "Título del botón de login",
+  "admin/editor.login.hideIconLabel": "",
   "admin/editor.login.providerPasswordButtonLabel": "Etiqueta del botón de login con Email/Password",
   "admin/editor.login.hasIdentifierExtension": "Extensión del identificador de usuario de Email/Password",
   "admin/editor.login.identifierPlaceholder": "Placeholder del campo de identificador",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -52,6 +52,7 @@
   "admin/editor.login.showPasswordVerificationIntoTooltip.title": "Exibir verificação do formato de senha como tooltip",
   "admin/editor.login.showIconProfile": "Exibir ícone de perfil",
   "admin/editor.login.iconLabel": "Título do botão de login",
+  "admin/editor.login.hideIconLabel": "Ocultar título do botão de login",
   "admin/editor.login.providerPasswordButtonLabel": "Texto do botão de login com E-mail/Senha",
   "admin/editor.login.hasIdentifierExtension": "Extensão do identificador de usuário de E-mail/Senha",
   "admin/editor.login.identifierPlaceholder": "Placeholder do campo de identificador",

--- a/react/Login.js
+++ b/react/Login.js
@@ -137,6 +137,11 @@ Login.getSchema = () => ({
       title: 'admin/editor.login.googleOneTap.title',
       type: 'boolean',
     },
+    hideIconLabel: {
+      title: 'admin/editor.login.hideIconLabel',
+      type: 'boolean',
+      default: false,
+    },
   },
   dependencies: {
     ...LoginSchema.dependencies,

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -61,7 +61,7 @@ class LoginComponent extends Component {
     const pathname = history && history.location && history.location.pathname
     const search = history && history.location && history.location.search
 
-    const iconClasses = 'flex items-center'
+    const iconClasses = `flex items-center ${hideIconLabel ? 'nr4' : ''}`
     const iconLabel = !hideIconLabel && (iconLabelProfile || translate('store/login.signIn', intl))
     const buttonContent = (
       <Fragment>
@@ -92,7 +92,7 @@ class LoginComponent extends Component {
             variation="tertiary"
             icon={
               showIconProfile && (
-                <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} iconClasses={iconClasses} />
+                <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} classes={iconClasses} />
               )
             }
             iconPosition={showIconProfile ? 'left' : 'right'}
@@ -127,7 +127,7 @@ class LoginComponent extends Component {
         variation="tertiary"
         icon={
           showIconProfile && (
-            <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} />
+            <ProfileIcon iconSize={iconSize} labelClasses={labelClasses} classes={iconClasses} />
           )
         }
         iconPosition={showIconProfile ? 'left' : 'right'}

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -48,6 +48,7 @@ class LoginComponent extends Component {
     const {
       iconSize,
       iconLabel: iconLabelProfile,
+      hideIconLabel,
       labelClasses,
       intl,
       loginButtonAsLink,
@@ -61,7 +62,7 @@ class LoginComponent extends Component {
     const search = history && history.location && history.location.search
 
     const iconClasses = 'flex items-center'
-    const iconLabel = iconLabelProfile || translate('store/login.signIn', intl)
+    const iconLabel = !hideIconLabel && (iconLabelProfile || translate('store/login.signIn', intl))
     const buttonContent = (
       <Fragment>
         {sessionProfile ? (

--- a/react/propTypes.js
+++ b/react/propTypes.js
@@ -20,6 +20,8 @@ export const LoginContainerProptypes = {
   iconSize: PropTypes.number,
   /** Icon's label */
   iconLabel: PropTypes.string,
+  /** Hide icon label */
+  hideIconLabel: PropTypes.bool,
   /** Label's classnames */
   labelClasses: PropTypes.string,
   /** Determines if the icon profile will be hidden */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `hideIconLabel` prop to `login` interface

#### What problem is this solving?
This also adds `hideIconLabel` to the site-editor. When true, it removes the iconLabel from the login button

#### How should this be manually tested?

Go into
https://rafaprtest2--storecomponents.myvtex.com/admin/cms/site-editor
Click "Login" in the right sidebar, then toggle "Hide login button label" to hide the label

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/22064061/89602740-c650a500-d83d-11ea-9c0f-2868fc9318c9.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
