### PR TITLE
Feature/is authenticated [VID-51]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Correctly identify whether the user is authenticated from the session profile object
+
 ## [2.36.3] - 2020-08-26
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.36.3",
+  "version": "2.37.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/Login.js
+++ b/react/Login.js
@@ -11,6 +11,8 @@ import getSessionProfile from './utils/getSessionProfile'
 
 const DEFAULT_CLASSES = 'gray'
 
+const LoginWithSession = injectIntl(LoginComponent)
+
 /** Canonical login that calls a mutation to retrieve the authentication token */
 
 export default class Login extends Component {
@@ -185,4 +187,3 @@ Login.uiSchema = {
   ],
 }
 
-const LoginWithSession = injectIntl(LoginComponent)

--- a/react/Login.js
+++ b/react/Login.js
@@ -75,7 +75,9 @@ export default class Login extends Component {
     const { logInButtonBehavior, accountOptionsButtonBehavior } = this.props
     const { sessionProfile, isMobileScreen } = this.state
     const buttonLink = ButtonBehavior.LINK
-    const shouldBeLink = isMobileScreen || (sessionProfile ? accountOptionsButtonBehavior === buttonLink : logInButtonBehavior === buttonLink)
+
+    const { isAuthenticated } = sessionProfile || {}
+    const shouldBeLink = isMobileScreen || (isAuthenticated ? accountOptionsButtonBehavior === buttonLink : logInButtonBehavior === buttonLink)
     
     return (
       <LoginWithSession

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -53,7 +53,11 @@ class LoginComponent extends Component {
       intl,
       loginButtonAsLink,
       onProfileIconClick,
-      sessionProfile,
+      sessionProfile: {
+        isAuthenticated,
+        firstName,
+        email
+      } = {},
       showIconProfile,
       runtime: { history, navigate },
     } = this.props
@@ -66,12 +70,12 @@ class LoginComponent extends Component {
 
     const buttonContent = hideIconLabel ? (
       <></>
-    ) : sessionProfile ? (
+    ) : isAuthenticated ? (
       <span
         className={`${styles.profile} truncate t-action--small order-1 pl4 ${labelClasses} dn db-l`}
       >
         {translate('store/login.hello', intl)}{' '}
-        {sessionProfile.firstName || sessionProfile.email}
+        {firstName || email}
       </span>
     ) : (
       <span
@@ -82,7 +86,7 @@ class LoginComponent extends Component {
     )
 
     if (loginButtonAsLink) {
-      const linkTo = sessionProfile ? 'store.account' : 'store.login'
+      const linkTo = isAuthenticated ? 'store.account' : 'store.login'
       return (
         <div className={styles.buttonLink}>
           <ButtonWithIcon
@@ -98,7 +102,7 @@ class LoginComponent extends Component {
                 return
               }
               const returnUrl =
-                !sessionProfile &&
+                !isAuthenticated &&
                 encodeURIComponent(`${pathname}${search}`)
               const bindingAddress = getBindingAddress()
               return navigate({
@@ -153,6 +157,8 @@ class LoginComponent extends Component {
      googleOneTapMarginTop,
     } = this.props
 
+    const { isAuthenticated } = sessionProfile || {}
+
     return (
       <div className={`${styles.container} flex items-center fr`}>
         <div className="relative">
@@ -161,7 +167,7 @@ class LoginComponent extends Component {
             <OneTapSignin
               alignment={googleOneTapAlignment}
               marginTop={googleOneTapMarginTop}
-              shouldOpen={!sessionProfile}
+              shouldOpen={!isAuthenticated}
             />
           )}
           {isBoxOpen && (

--- a/react/components/LoginComponent.js
+++ b/react/components/LoginComponent.js
@@ -53,14 +53,16 @@ class LoginComponent extends Component {
       intl,
       loginButtonAsLink,
       onProfileIconClick,
-      sessionProfile: {
-        isAuthenticated,
-        firstName,
-        email
-      } = {},
+      sessionProfile,
       showIconProfile,
       runtime: { history, navigate },
     } = this.props
+
+    const {
+      isAuthenticated,
+      firstName,
+      email
+    } = sessionProfile || {}
 
     const pathname = history && history.location && history.location.pathname
     const search = history && history.location && history.location.search

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -188,13 +188,19 @@ class LoginContent extends Component {
   }
 
   get shouldRenderForm() {
-    if (this.props.profile) {
+    const {
+      isHeaderLogin,
+      isInitialScreenOptionOnly,
+    } = this.props
+    const {
+      sessionProfile,
+      isOnInitialScreen,
+    } = this.state
+
+    if (isHeaderLogin && sessionProfile) {
       return true
     }
-
-    return (
-      !this.props.isInitialScreenOptionOnly || !this.state.isOnInitialScreen
-    )
+    return !(isInitialScreenOptionOnly && isOnInitialScreen)
   }
 
   shouldRedirectToOAuth = loginOptions => {
@@ -264,16 +270,19 @@ class LoginContent extends Component {
 
   renderChildren = () => {
     const {
-      profile,
+      isHeaderLogin,
       isInitialScreenOptionOnly,
       optionsTitle,
       defaultOption,
       providerPasswordButtonLabel,
     } = this.props
-    const { isOnInitialScreen } = this.state
+    const {
+      isOnInitialScreen,
+      sessionProfile,
+    } = this.state
 
     let step = this.state.step
-    if (profile) {
+    if (isHeaderLogin && sessionProfile) {
       step = steps.ACCOUNT_OPTIONS
     } else if (isOnInitialScreen) {
       step = defaultOption
@@ -321,25 +330,25 @@ class LoginContent extends Component {
 
   render() {
     const {
-      profile,
+      isHeaderLogin,
       isInitialScreenOptionOnly,
       defaultOption,
       runtime,
-      isHeaderLogin,
     } = this.props
 
-    const { isOnInitialScreen, sessionProfile } = this.state
+    const {
+      isOnInitialScreen,
+      sessionProfile
+    } = this.state
 
-    // Check if the user is already logged and redirect to the return URL if it didn't receive
-    // the profile by the props and current endpoint are /login, if receive it, should render the account options.
-    if (sessionProfile && !profile) {
+    if (!isHeaderLogin && sessionProfile) {
       if (location.pathname.includes('/login')) {
         jsRedirect({ runtime, isHeaderLogin })
       }
     }
 
     let step = this.state.step
-    if (profile) {
+    if (isHeaderLogin && sessionProfile) {
       step = steps.ACCOUNT_OPTIONS
     } else if (isOnInitialScreen) {
       step = defaultOption
@@ -371,7 +380,7 @@ class LoginContent extends Component {
     
     return (
       <div className={className}>
-        {!profile && this.shouldRenderLoginOptions
+        {!(isHeaderLogin && sessionProfile) && this.shouldRenderLoginOptions
           ? this.renderChildren()
           : null}
         <div className={formClassName}>

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -161,7 +161,7 @@ class LoginContent extends Component {
 
   state = {
     sessionProfile: this.props.profile,
-    isOnInitialScreen: !this.props.profile,
+    isOnInitialScreen: !this.props.profile || !this.props.profile.isAuthenticated,
     isCreatePassword: this.props.defaultIsCreatePassword,
     step: this.props.defaultOption,
     email: '',
@@ -193,11 +193,11 @@ class LoginContent extends Component {
       isInitialScreenOptionOnly,
     } = this.props
     const {
-      sessionProfile,
+      sessionProfile: { isAuthenticated } = {},
       isOnInitialScreen,
     } = this.state
 
-    if (isHeaderLogin && sessionProfile) {
+    if (isHeaderLogin && isAuthenticated) {
       return true
     }
     return !(isInitialScreenOptionOnly && isOnInitialScreen)
@@ -278,11 +278,11 @@ class LoginContent extends Component {
     } = this.props
     const {
       isOnInitialScreen,
-      sessionProfile,
+      sessionProfile: { isAuthenticated } = {},
     } = this.state
 
     let step = this.state.step
-    if (isHeaderLogin && sessionProfile) {
+    if (isHeaderLogin && isAuthenticated) {
       step = steps.ACCOUNT_OPTIONS
     } else if (isOnInitialScreen) {
       step = defaultOption
@@ -338,17 +338,17 @@ class LoginContent extends Component {
 
     const {
       isOnInitialScreen,
-      sessionProfile
+      sessionProfile: { isAuthenticated } = {}
     } = this.state
 
-    if (!isHeaderLogin && sessionProfile) {
+    if (!isHeaderLogin && isAuthenticated) {
       if (location.pathname.includes('/login')) {
         jsRedirect({ runtime, isHeaderLogin })
       }
     }
 
     let step = this.state.step
-    if (isHeaderLogin && sessionProfile) {
+    if (isHeaderLogin && isAuthenticated) {
       step = steps.ACCOUNT_OPTIONS
     } else if (isOnInitialScreen) {
       step = defaultOption
@@ -380,7 +380,7 @@ class LoginContent extends Component {
     
     return (
       <div className={className}>
-        {!(isHeaderLogin && sessionProfile) && this.shouldRenderLoginOptions
+        {!(isHeaderLogin && isAuthenticated) && this.shouldRenderLoginOptions
           ? this.renderChildren()
           : null}
         <div className={formClassName}>
@@ -473,7 +473,7 @@ const LoginContentProvider = props => {
 
   return (
     <AuthStateLazy
-      skip={!!props.profile}
+      skip={!!(props.profile && props.profile.isAuthenticated)}
       scope="STORE"
       parentAppId={SELF_APP_NAME_AND_VERSION}
       returnUrl={redirectUrl}

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -161,7 +161,7 @@ class LoginContent extends Component {
 
   state = {
     sessionProfile: this.props.profile,
-    isOnInitialScreen: !this.props.profile || !this.props.profile.isAuthenticated,
+    isOnInitialScreen: !(this.props.profile && this.props.profile.isAuthenticated),
     isCreatePassword: this.props.defaultIsCreatePassword,
     step: this.props.defaultOption,
     email: '',

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -193,9 +193,11 @@ class LoginContent extends Component {
       isInitialScreenOptionOnly,
     } = this.props
     const {
-      sessionProfile: { isAuthenticated } = {},
+      sessionProfile,
       isOnInitialScreen,
     } = this.state
+
+    const { isAuthenticated } = sessionProfile || {}
 
     if (isHeaderLogin && isAuthenticated) {
       return true
@@ -278,8 +280,10 @@ class LoginContent extends Component {
     } = this.props
     const {
       isOnInitialScreen,
-      sessionProfile: { isAuthenticated } = {},
+      sessionProfile,
     } = this.state
+
+    const { isAuthenticated } = sessionProfile || {}
 
     let step = this.state.step
     if (isHeaderLogin && isAuthenticated) {
@@ -338,8 +342,10 @@ class LoginContent extends Component {
 
     const {
       isOnInitialScreen,
-      sessionProfile: { isAuthenticated } = {}
+      sessionProfile,
     } = this.state
+
+    const { isAuthenticated } = sessionProfile || {}
 
     if (!isHeaderLogin && isAuthenticated) {
       if (location.pathname.includes('/login')) {

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -65,7 +65,9 @@ const OneTapSignin = ({
   useEffect(() => {
     if (!shouldOpen) return
 
-    getSessionProfile().then(async ({ isAuthenticated } = {}) => {
+    getSessionProfile().then(async sessionProfile => {
+      const { isAuthenticated } = sessionProfile || {}
+
       if (isAuthenticated) return
 
       const { href: baseUrl } = window.location

--- a/react/components/OneTapSignin.js
+++ b/react/components/OneTapSignin.js
@@ -7,7 +7,6 @@ import {
   GoogleOneTapAlignment,
   SELF_APP_NAME_AND_VERSION,
 } from '../common/global'
-import { getProfile } from '../utils/profile'
 import getSessionProfile from '../utils/getSessionProfile'
 
 const onLoginPage = current => current === 'store.login'
@@ -66,8 +65,8 @@ const OneTapSignin = ({
   useEffect(() => {
     if (!shouldOpen) return
 
-    getSessionProfile().then(async data => {
-      if (data) return
+    getSessionProfile().then(async ({ isAuthenticated } = {}) => {
+      if (isAuthenticated) return
 
       const { href: baseUrl } = window.location
       const resp = await fetch(

--- a/react/utils/profile.js
+++ b/react/utils/profile.js
@@ -28,7 +28,7 @@ const getProfileFromApiResponse = data => {
     isAuthenticated: { value: isAuthenticated } = { value: false },
   } = profile
 
-  if (!isAuthenticated || !email) {
+  if (isAuthenticated && !email) {
     return null
   }
 

--- a/react/utils/profile.js
+++ b/react/utils/profile.js
@@ -25,15 +25,17 @@ const getProfileFromApiResponse = data => {
   const {
     email: { value: email } = { value: null },
     firstName: { value: firstName } = { value: null },
+    isAuthenticated: { value: isAuthenticated } = { value: false },
   } = profile
 
-  if (!email) {
+  if (!isAuthenticated || !email) {
     return null
   }
 
   return {
     email,
     firstName,
+    isAuthenticated,
   }
 }
 

--- a/react/utils/profile.js
+++ b/react/utils/profile.js
@@ -22,8 +22,10 @@ const getProfileFromApiResponse = data => {
   const {
     email: { value: email } = { value: null },
     firstName: { value: firstName } = { value: null },
-    isAuthenticated: { value: isAuthenticated } = { value: false },
+    isAuthenticated: { value: isAuthenticatedValue } = { value: false },
   } = profile
+
+  const isAuthenticated = isAuthenticatedValue === 'true'
 
   if (isAuthenticated && !email) {
     return null

--- a/react/utils/profile.js
+++ b/react/utils/profile.js
@@ -13,11 +13,8 @@ const getProfileFromQueryResponse = data => {
 }
 
 const getProfileFromApiResponse = data => {
-  if (!data || !data.namespaces) {
-    return null
-  }
-
-  const { namespaces: { profile } = {} } = data
+  const { namespaces } = data || {}
+  const { profile } = namespaces || {}
   if (!profile) {
     return null
   }


### PR DESCRIPTION
#### What problem is this solving?

This checks for session profile's `isAuthenticated` property instead of just checking the user email. This makes it possible to identify the user before he/she logs in.

#### How to test it?

Check the login still works in the header and login page:
https://rafaprtest--storecomponents.myvtex.com
https://rafaprtest--storecomponents.myvtex.com/login

Also, use a proxy to rewrite the response body of calls to `/api/sessions/items=&__bindingId=*`, replacing the following regexes for each value:
`"isAuthenticated":\s*\{\s*"value":\s*".+?"\s*\}` -> `"isAuthenticated": { "value": "false" }`
`"email":\s*\{\s*"value":\s*".+?"\s*\}` -> `"email": { "value": "example@email.com" }`

Then reload the page. You will see the user is not considered to be logged in, since "isAuthentication" was set to false.
![image](https://user-images.githubusercontent.com/22064061/90193974-8721d700-dd9c-11ea-857b-1331722f7419.png)

Then, change `"isAuthenticated": { "value": "false" }` for `"isAuthenticated": { "value": "true" }` in your rewrite proxy. Reload the page, and you'll see user is considered to be logged in:

![image](https://user-images.githubusercontent.com/22064061/90193878-4033e180-dd9c-11ea-8ef5-8c967f5a696a.png)
