### PR TITLE
Feature/email from session [VID-52]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Fill email fields by default with the value from session
+
 ## [2.37.1] - 2020-09-08
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.37.1",
+  "version": "2.38.0-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -4,5 +4,10 @@
     "browser": true,
     "es6": true,
     "jest": true
+  },
+  "rules": {
+    "react-hooks/exhaustive-deps": ["warn", {
+      "additionalHooks": "^useAsyncCallback$"
+    }]
   }
 }

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -469,15 +469,21 @@ const LoginContentProvider = props => {
   )
 
   const [profile, setProfile] = useState(props.profile)
+  const [loadingProfile, setLoadingProfile] = useState(!props.profile)
 
   useEffect(async () => {
     const sessionProfile = await getSessionProfile()
     if (sessionProfile) {
       setProfile(sessionProfile)
     }
+    setLoadingProfile(false)
   }, [])
 
-  const userEmail = getUserEmailQuery()
+  const userEmail = (profile && profile.email) || getUserEmailQuery()
+  
+  if (loadingProfile) {
+    return <Loading />
+  }
 
   return (
     <AuthStateLazy

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -1,4 +1,4 @@
-import React, { Component, Suspense, useMemo } from 'react'
+import React, { Component, Suspense, useMemo, useState, useEffect } from 'react'
 
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
@@ -475,6 +475,15 @@ const LoginContentProvider = props => {
     [props.isHeaderLogin]
   )
 
+  const [profile, setProfile] = useState(props.profile)
+
+  useEffect(async () => {
+    const sessionProfile = await getSessionProfile()
+    if (sessionProfile) {
+      setProfile(sessionProfile)
+    }
+  }, [])
+
   const userEmail = getUserEmailQuery()
 
   return (
@@ -494,7 +503,13 @@ const LoginContentProvider = props => {
         return (
           <AuthServiceLazy.RedirectAfterLogin>
             {({ action: apiRedirect }) => (
-              <LoginContentWrapper {...props} intl={intl} runtime={runtime} apiRedirect={apiRedirect} />
+              <LoginContentWrapper
+                {...props}
+                profile={profile}
+                intl={intl}
+                runtime={runtime}
+                apiRedirect={apiRedirect}
+              />
             )}
           </AuthServiceLazy.RedirectAfterLogin>
       )}}

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -160,7 +160,6 @@ class LoginContent extends Component {
   }
 
   state = {
-    sessionProfile: this.props.profile,
     isOnInitialScreen: !(this.props.profile && this.props.profile.isAuthenticated),
     isCreatePassword: this.props.defaultIsCreatePassword,
     step: this.props.defaultOption,
@@ -173,12 +172,6 @@ class LoginContent extends Component {
     if (location.href.indexOf('accountAuthCookieName') > 0) {
       setCookie(location.href)
     }
-
-    getSessionProfile().then(sessionProfile => {
-      if (sessionProfile) {
-        this.setState({ sessionProfile })
-      }
-    })
   }
 
   get shouldRenderLoginOptions() {
@@ -191,13 +184,13 @@ class LoginContent extends Component {
     const {
       isHeaderLogin,
       isInitialScreenOptionOnly,
+      profile,
     } = this.props
     const {
-      sessionProfile,
       isOnInitialScreen,
     } = this.state
 
-    const { isAuthenticated } = sessionProfile || {}
+    const { isAuthenticated } = profile || {}
 
     if (isHeaderLogin && isAuthenticated) {
       return true
@@ -277,13 +270,13 @@ class LoginContent extends Component {
       optionsTitle,
       defaultOption,
       providerPasswordButtonLabel,
+      profile,
     } = this.props
     const {
       isOnInitialScreen,
-      sessionProfile,
     } = this.state
 
-    const { isAuthenticated } = sessionProfile || {}
+    const { isAuthenticated } = profile || {}
 
     let step = this.state.step
     if (isHeaderLogin && isAuthenticated) {
@@ -338,14 +331,14 @@ class LoginContent extends Component {
       isInitialScreenOptionOnly,
       defaultOption,
       runtime,
+      profile,
     } = this.props
 
     const {
       isOnInitialScreen,
-      sessionProfile,
     } = this.state
 
-    const { isAuthenticated } = sessionProfile || {}
+    const { isAuthenticated } = profile || {}
 
     if (!isHeaderLogin && isAuthenticated) {
       if (location.pathname.includes('/login')) {

--- a/react/utils/useAsyncCallback.js
+++ b/react/utils/useAsyncCallback.js
@@ -1,0 +1,30 @@
+import { useState, useCallback, useEffect } from 'react'
+
+const useAsyncCallback = (callback, depsLst, { autorun = false } = {}) => {
+  const [value, setValue] = useState(null)
+  const [loading, setLoading] = useState(autorun)
+
+  const memoizedCallback = useCallback(callback, depsLst)
+
+  const wrappedCallback = useCallback(
+    async (...args) => {
+      setLoading(true)
+
+      const newValue = await memoizedCallback(...args)
+      setValue(newValue)
+      setLoading(false)
+      return newValue
+    },
+    [memoizedCallback]
+  )
+
+  useEffect(() => {
+    if (autorun) {
+      wrappedCallback()
+    }
+  }, [autorun, wrappedCallback])
+
+  return [wrappedCallback, { value, loading }]
+}
+
+export default useAsyncCallback


### PR DESCRIPTION
#### What problem is this solving?
Fill email fields with the value from session profile.
The login now must wait for `sessionPromise` to resolve before loading.
Also, this stops using `sessionPromise` from the window object when it's not needed.

#### How to test it?

Check the login still works in the header and login page:
https://rafaprtest2--storecomponents.myvtex.com/
https://rafaprtest2--storecomponents.myvtex.com/login

Also, use a proxy to rewrite the response body of calls to /api/sessions/items=&__bindingId=*, replacing the following regex for the value:
`"profile":\s*\{(\s*".+?":\s*\{\s*"value":\s*".+?"\})+?\s*\}` -> `"profile": { "isAuthenticated": { "value": "false" }, "email": { "value": "example@email.com" } }`
(This emulates an unauthenticated, but identified user)

Then reload the page. Try to log in using email/password or email/access token. You'll see that the `email` field is filled by default with the email from the session profile.
