### PR TITLE
Fix/close popup error [VID-125]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- "Unknown error" message appeared when OAuth popup was closed
+
 ## [2.36.1] - 2020-08-20
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.36.1",
+  "version": "2.36.2-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/components/OAuth.js
+++ b/react/components/OAuth.js
@@ -30,8 +30,11 @@ class OAuth extends Component {
     onOAuthError: PropTypes.func.isRequired,
   }
 
-  handleOAuthPopupFailure = err =>
-    this.props.onOAuthError(err.details)
+  handleOAuthPopupFailure = err => {
+    if (err.code == 'OAuthError') {
+      this.props.onOAuthError(err.details)
+    }
+  }
 
   render() {
     const { intl, children, provider, onLoginSuccess, onLoginError } = this.props


### PR DESCRIPTION
#### What problem is this solving?

This fixes "unknown error" message appearing when OAuth popup was closed

#### How to test it?

Go into
https://rafaprtest7--storecomponents.myvtex.com/
And open the login popover, then click `Sign in with Facebook`. Close the popup window that opens up, and you'll see no error message in the popover. Compare it to the `master` workspace, where the error shows up.
