### PR TITLE
Fix/vid 126/auto redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `/login` page not auto redirecting logged user when `returnUrl` didn't exist
+
 ## [2.36.2] - 2020-08-24
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.36.2",
+  "version": "2.36.3-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/react/utils/redirect.js
+++ b/react/utils/redirect.js
@@ -22,16 +22,20 @@ export const getDefaultRedirectUrl = isHeaderLogin => {
 export const jsRedirect = ({ runtime, isHeaderLogin }) => {
   const url = getReturnUrl() || getDefaultRedirectUrl(isHeaderLogin)
 
-  if (!url) {
-    const __bindingAddress = getBindingAddress()
-    const queryString = __bindingAddress
-      ? new URLSearchParams({ __bindingAddress }).toString()
-      : ''
-    return `${getRootPath()}/?${queryString}`
+  if (url) {
+    runtime.navigate({
+      to: url,
+      fallbackToWindowLocation: true,
+    })
+    return
   }
 
+  const __bindingAddress = getBindingAddress()
+  const queryString = __bindingAddress
+    ? new URLSearchParams({ __bindingAddress }).toString()
+    : ''
   runtime.navigate({
-    to: url,
+    to: `${getRootPath()}/?${queryString}`,
     fallbackToWindowLocation: true,
   })
 }


### PR DESCRIPTION
#### What problem is this solving?

This fixes logged users not being redirected when `returnUrl` didn't exist

#### How to test it?

Go into
https://rafaprtest8--storecomponents.myvtex.com/
and log in.
Then go into
https://rafaprtest8--storecomponents.myvtex.com/login
You should be automatically redirected to the store home page
