### PR TITLE
Fix/VID-104/stop changing state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- State change happening after "set password" and before redirect
+
+### Removed
+
+- `postreleasy` script to publish app (VTEX CD does it instead)
+
 ## [2.37.0] - 2020-09-08
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "login",
-  "version": "2.37.0",
+  "version": "2.37.1-beta.0",
   "title": "VTEX Login",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Login app",

--- a/manifest.json
+++ b/manifest.json
@@ -12,9 +12,6 @@
     "docs": "0.x"
   },
   "mustUpdateAt": "2019-04-02",
-  "scripts": {
-    "postreleasy": "vtex publish --verbose"
-  },
   "dependencies": {
     "vtex.styleguide": "9.x",
     "vtex.store-icons": "0.x",

--- a/react/components/LoginContent.js
+++ b/react/components/LoginContent.js
@@ -93,7 +93,7 @@ const STEPS = [
     return style => (
       <div style={style} key={4}>
         <RecoveryPassword
-          next={steps.ACCOUNT_OPTIONS}
+          next={steps.CREATE_PASSWORD}
           previous={steps.EMAIL_PASSWORD}
           passwordPlaceholder={props.passwordPlaceholder}
           showPasswordVerificationIntoTooltip={


### PR DESCRIPTION
#### What problem is this solving?
Stop briefly changing login flow state after "set password" and  before redirect

#### How to test it?

Go into
https://rafaprtest--storecomponents.myvtex.com/
And click the login button, then `Sign in with email and password`, then `Forgot my password`. Enter your email, then press `Send` and proceed entering the access code sent to your email. Choose a new password to set, then click `Create`.
Before this fix, your account options would briefly appear before the browser redirects you (test it in https://storecomponents.myvtex.com/). Now, instead, you'll see nothing happen until you're redirected.
Loading feedback will be added in another PR (since it's a general problem throughout the app)
